### PR TITLE
Initial implementation of CI for bluejay

### DIFF
--- a/.changelog-configuration.json
+++ b/.changelog-configuration.json
@@ -1,0 +1,30 @@
+{
+    "categories": [
+        {
+            "title": "## Features",
+            "labels": ["feature"]
+        },
+        {
+            "title": "## Fixes",
+            "labels": ["fix"]
+        },
+        {
+            "title": "## Performance",
+            "labels": ["performance"]
+        },
+        {
+            "title": "## Tests",
+            "labels": ["test"]
+        },
+        {
+            "title": "## Chores",
+            "labels": ["chore"]
+        }
+    ],
+    "sort": "ASC",
+    "template": "${{CHANGELOG}}",
+    "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+    "empty_template": "- no changes",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 1000
+}

--- a/.github/workflows/add_artifact_urls.yml
+++ b/.github/workflows/add_artifact_urls.yml
@@ -1,0 +1,21 @@
+name: add artifact links to pull request and related issues
+on:
+  workflow_run:
+    workflows: ['Build Firmware']
+    types: [completed]
+
+jobs:
+  artifacts-url-comments:
+    name: add artifact links to pull request and related issues job
+    runs-on: windows-2019
+    steps:
+      - name: add artifact links to pull request and related issues step
+        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            prefix: Here are the build results
+            suffix: Artifacts will only be retained for 30 days.
+            format: name
+            addTo: pullandissues
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Build Bluejay Firmware.
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '*'
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/bird-sanctuary/bluejay-builder
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      # TODO: See if we should cache the ~/.wine directory
+      - name: Prepare environment
+        env:
+          BUILD_ENV_URL: ${{ secrets.BUILD_ENV_URL }}
+          BUILD_ENV_PASSWORD: ${{ secrets.BUILD_ENV_PASSWORD }}
+        run: |
+          rm -rf ~/.wine
+          wget -c "$BUILD_ENV_URL" -O wine.zip
+          unzip -P "$BUILD_ENV_PASSWORD" wine.zip -d ~/
+
+      - name: Build Firmware
+        run: make all
+
+      # TODO: Automate changelog generation and creating releases
+      - name: Publish build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Assets
+          path: ./build/hex/*.hex
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v3
+        with:
+          configuration: ".changelog-configuration.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: Assets
+          name: bluejay_ci_${{ github.run_number }}
           path: ./build/hex/*.hex
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           path: ~/.wine
           key: toolchain-cache
 
-      - name: Prepare environment
+      - name: Prepare build environment
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
         env:
           BUILD_ENV_URL: ${{ secrets.BUILD_ENV_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build Firmware.
+name: Build Firmware
 
 on:
   push:
@@ -50,7 +50,7 @@ jobs:
         with:
           name: bluejay_ci_${{ github.run_number }}
           path: ./build/hex/*.hex
-          retention-days: 7
+          retention-days: 30
 
       - name: Build Changelog
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.wine
-          key: toolchain-${{ hashFiles('~/.wine/drive_c/Keil_v5/TOOLS.INI') }}
+          key: toolchain-cache
 
       - name: Prepare environment
-        if: steps.cache-toolchian.outputs.cache-hit != 'true'
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
         env:
           BUILD_ENV_URL: ${{ secrets.BUILD_ENV_URL }}
           BUILD_ENV_PASSWORD: ${{ secrets.BUILD_ENV_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,16 @@
-name: Build Bluejay Firmware.
+name: Build Firmware.
 
 on:
   push:
     branches:
-    - main
+      - main
+      - develop
     tags:
-    - '*'
+      - '*'
   pull_request:
     branches:
-    - main
+      - main
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,15 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v2
 
-      # TODO: See if we should cache the ~/.wine directory
+      - name: Cache Toolchain
+        id: cache-toolchain
+        uses: actions/cache@v3
+        with:
+          path: ~/.wine
+          key: toolchain-${{ hashFiles('~/.wine/drive_c/Keil_v5/TOOLS.INI') }}
+
       - name: Prepare environment
+        if: steps.cache-toolchian.outputs.cache-hit != 'true'
         env:
           BUILD_ENV_URL: ${{ secrets.BUILD_ENV_URL }}
           BUILD_ENV_PASSWORD: ${{ secrets.BUILD_ENV_PASSWORD }}
@@ -36,8 +43,7 @@ jobs:
       - name: Build Firmware
         run: make all
 
-      # TODO: Automate changelog generation and creating releases
-      - name: Publish build artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: bluejay_ci_${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,17 @@ jobs:
           name: bluejay_ci_${{ github.run_number }}
           path: ./build/hex/*.hex
           retention-days: 7
+
+      - name: Build Changelog
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          body: ${{steps.github_release.outputs.changelog}}
+          files: ./build/hex/*.hex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           wget -c "$BUILD_ENV_URL" -O wine.zip
           unzip -P "$BUILD_ENV_PASSWORD" wine.zip -d ~/
 
-      - name: Build Firmware
+      - name: Build
         run: make all
 
       - name: Upload build artifacts
@@ -52,7 +52,7 @@ jobs:
           path: ./build/hex/*.hex
           retention-days: 30
 
-      - name: Build Changelog
+      - name: Generate Changelog
         if: startsWith(github.ref, 'refs/tags/v')
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v3


### PR DESCRIPTION
This simply builds all the targets and uploads them as build artifacts

### TODO:
- [x] ~~Cache the development environment~~ The only reason to do this is if we want to save up on data transfer costs from the external hosting. This step takes only 8 seconds otherwise.
- [x] Automate releases
- [x] Automate changelog generation

