### PR TITLE
Temperature fix for 1S, updated MCU_48MHZ identifier to MCU_TYPE for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /tools/.wine
 *.diff
+.project
+

--- a/BLHeliBootLoad.inc
+++ b/BLHeliBootLoad.inc
@@ -3,9 +3,9 @@
 XTAL					EQU	25000000
 
 ; Bootloader segment address
-IF MCU_48MHZ < 2
+IF MCU_TYPE < 2
 	BOOT_START		EQU	1C00h
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	BOOT_START		EQU	0F000h
 ENDIF
 
@@ -58,7 +58,7 @@ init:clr	IE_EA
 	mov	SP, #0c0h				; Stack = 64 upper bytes of RAM
 	; Initialize clock
 	mov	CLKSEL, #00h			; Set clock divider to 1
-	IF MCU_48MHZ < 2
+	IF MCU_TYPE < 2
 		; Initialize VDD monitor
 		orl	VDM0CN, #080h		; Enable the VDD monitor
 	ENDIF
@@ -239,9 +239,9 @@ pro4:djnz	Xl, pro5
 pro5:
 	clr	C
 	mov	A, DPH				; Check that address is not in bootloader area
-	IF MCU_48MHZ < 2
+	IF MCU_TYPE < 2
 		subb A, #1Ch
-	ELSEIF MCU_48MHZ == 2
+	ELSEIF MCU_TYPE == 2
 		subb A, #0F0h
 	ENDIF
 	jc	($+5)

--- a/Common.inc
+++ b/Common.inc
@@ -29,11 +29,11 @@
 ;*********************
 ; Device SiLabs EFM8BB1x/2x/51
 ;*********************
-IF MCU_48MHZ == 0
+IF MCU_TYPE == 0
 	$include (Silabs/SI_EFM8BB1_Defs.inc)
-ELSEIF MCU_48MHZ == 1
+ELSEIF MCU_TYPE == 1
 	$include (Silabs/SI_EFM8BB2_Defs.inc)
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	$include (Silabs/SI_EFM8BB51_Defs.inc)
 ENDIF
 
@@ -43,7 +43,7 @@ ENDIF
 
 ;**** **** **** **** ****
 ; ESC selection statements
-IF MCU_48MHZ < 2
+IF MCU_TYPE < 2
 	IF ESCNO == A_
 	$include (Layouts/A.inc)				; Select pinout A
 	ELSEIF ESCNO == B_
@@ -99,7 +99,7 @@ IF MCU_48MHZ < 2
 	ENDIF
 ENDIF
 
-IF MCU_48MHZ == 2
+IF MCU_TYPE == 2
 	IF ESCNO == A_
 	$include (Layouts/BB51/A.inc)			; Select pinout A
 	ELSEIF ESCNO == B_
@@ -110,11 +110,11 @@ IF MCU_48MHZ == 2
 ENDIF
 
 SIGNATURE_001			EQU	0E8h		; Device signature
-IF MCU_48MHZ == 0
+IF MCU_TYPE == 0
 	SIGNATURE_002			EQU	0B1h
-ELSEIF MCU_48MHZ == 1
+ELSEIF MCU_TYPE == 1
 	SIGNATURE_002			EQU	0B2h
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	SIGNATURE_002			EQU	0B5h
 ENDIF
 
@@ -124,11 +124,11 @@ ENDIF
 ESC_C	EQU	"A" + ESCNO - 1		; ESC target letter
 
 ; MCU letter (24Mhz=L, 48Mhz=H, BB51=X)
-IF MCU_48MHZ == 0
+IF MCU_TYPE == 0
 	MCU_C	EQU	"L"
-ELSEIF MCU_48MHZ == 1
+ELSEIF MCU_TYPE == 1
 	MCU_C	EQU	"H"
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	MCU_C	EQU	"X"
 ENDIF
 ENDIF
@@ -139,9 +139,9 @@ DT_C1	EQU	"0" + ((DEADTIME / 10) MOD 10)
 DT_C0	EQU	"0" + (DEADTIME MOD 10)
 
 ; ESC layout tag
-IF MCU_48MHZ < 2
+IF MCU_TYPE < 2
 	CSEG AT 1A40h
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	CSEG AT 3040h
 ENDIF
 
@@ -151,18 +151,18 @@ ELSE
 Eep_ESC_Layout:	DB	"#", ESC_C, "_", MCU_C, "_", DT_C2, DT_C1, DT_C0, "#       "
 ENDIF
 
-IF MCU_48MHZ < 2
+IF MCU_TYPE < 2
 	CSEG AT 1A50h
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	CSEG AT 3050h
 ENDIF
 
 ; Project and MCU tag (16 Bytes)
-IF MCU_48MHZ == 0
+IF MCU_TYPE == 0
 	Eep_ESC_MCU:	DB	"#BLHELI$EFM8B10#"
-ELSEIF MCU_48MHZ == 1
+ELSEIF MCU_TYPE == 1
 	Eep_ESC_MCU:	DB	"#BLHELI$EFM8B21#"
-ELSEIF MCU_48MHZ == 2
+ELSEIF MCU_TYPE == 2
 	Eep_ESC_MCU:	DB	"#BLHELI$EFM8B51#"
 ENDIF
 
@@ -208,9 +208,9 @@ ENDM
 
 Set_MCU_Clk_48MHz MACRO
 	mov	SFRPAGE, #10h
-	IF MCU_48MHZ == 1
+	IF MCU_TYPE == 1
 		mov	PFE0CN, #30h			;; Set flash timing for 48MHz and enable prefetch engine
-	ELSEIF MCU_48MHZ == 2
+	ELSEIF MCU_TYPE == 2
 		mov	PFE0CN, #10h			;; Set flash timing for 48MHz
 	ENDIF
 	mov	SFRPAGE, #00h

--- a/Layouts/Base.inc
+++ b/Layouts/Base.inc
@@ -120,41 +120,41 @@ ENDIF
 Initialize_Comparator MACRO
 	mov	CMP_CN0, #80h				;; Comparator enabled, no hysteresis
 	mov	CMP_MD, #00h				;; Comparator response time 100ns
-IF COMPARATOR_INVERT == 1 AND MCU_48MHZ >= 1
+IF COMPARATOR_INVERT == 1 AND MCU_TYPE >= 1
 	mov	CMP_MD, #40h				;; Output polarity inverted (Only supported on BB2 and BB51)
 ENDIF
 ENDM
 
 Read_Comparator_Output MACRO
 	mov	A, CMP_CN0				;; Read comparator output
-IF COMPARATOR_INVERT == 1 AND MCU_48MHZ == 0
+IF COMPARATOR_INVERT == 1 AND MCU_TYPE == 0
 	cpl	A						;; Invert output polarity manually on BB1
 ENDIF
 ENDM
 
 ; Set comparator multiplexer to phase A
 Set_Comparator_Phase_A MACRO
-	IF MCU_48MHZ < 2
+	IF MCU_TYPE < 2
 		mov	CMP_MX, #((A_Mux SHL 4) + V_Mux)
-	ELSEIF MCU_48MHZ == 2
+	ELSEIF MCU_TYPE == 2
 		mov	CMP_MX, #12h
 	ENDIF
 ENDM
 
 ; Set comparator multiplexer to phase B
 Set_Comparator_Phase_B MACRO
-	IF MCU_48MHZ < 2
+	IF MCU_TYPE < 2
 		mov	CMP_MX, #((B_Mux SHL 4) + V_Mux)
-	ELSEIF MCU_48MHZ == 2
+	ELSEIF MCU_TYPE == 2
 		mov	CMP_MX, #10h
 	ENDIF
 ENDM
 
 ; Set comparator multiplexer to phase C
 Set_Comparator_Phase_C MACRO
-	IF MCU_48MHZ < 2
+	IF MCU_TYPE < 2
 		mov	CMP_MX, #((C_Mux SHL 4) + V_Mux)
-	ELSEIF MCU_48MHZ == 2
+	ELSEIF MCU_TYPE == 2
 		mov	CMP_MX, #11h
 	ENDIF
 ENDM
@@ -328,43 +328,50 @@ $endif
 ; ADC and temperature measurement
 ;**** **** **** **** ****
 ; Temperature measurement ADC value for which main motor power is limited at 80degC (low byte, assuming high byte is 1)
-IF MCU_48MHZ < 2
-	TEMP_LIMIT		    EQU	49
-ELSEIF MCU_48MHZ == 2
-	TEMP_LIMIT		    EQU	92	; 0degC is on the BB51 at 0x0114 so ((92 - 20) / 9 * 10) = 80degC
-ENDIF
+TEMP_LIMIT_2S		EQU	49  ; When using vdd 3.3V reference
+TEMP_LIMIT_1S       EQU 92  ; When using 1.65V internal reference
 TEMP_LIMIT_STEP		EQU	9		; Temperature measurement ADC value increment for another 10degC
 
 Initialize_Adc MACRO
-	IF MCU_48MHZ < 2
-		mov	REF0CN, #0Ch			;; Set vdd (3.3V) as reference. Enable temp sensor and bias
-		IF MCU_48MHZ == 0
-			mov	ADC0CF, #59h		;; ADC clock 2MHz, PGA gain 1
-		ELSEIF MCU_48MHZ == 1
-			mov	ADC0CF, #0B9h		;; ADC clock 2MHz, PGA gain 1
-		ENDIF
-	ELSEIF MCU_48MHZ == 2
-		mov	CLKGRP0, #18h			;; Enable SAR clock, at 12MHz
-		mov	ADC0CF1, #0Ah			;; 800ns tracking time
-		mov	ADC0CF2, #2Fh			;; 1.65V reference
-	ENDIF
+LOCAL initialize_adc_use_internal_1V65_vref initialize_adc_use_vdd_3V3_vref initialize_adc_vref_selected
+IF MCU_TYPE < 2
+    mov Temp1, #Pgm_Power_Rating
+    cjne @Temp1, #01h, initialize_adc_use_vdd_3V3_vref
 
-	mov	ADC0MX, #10h				;; Select temp sensor input
-	IF MCU_48MHZ < 2
-		mov	ADC0CN0, #80h			;; ADC enabled
-		mov	ADC0CN1, #01h			;; Common mode buffer enabled
-	ELSEIF MCU_48MHZ == 2
-		mov	ADC0CN0, #85h			;; ADC enabled (gain 0.5, temp sensor enabled)
-		mov	ADC0CN1, #20h			;; 10bit mode
-	ENDIF
+initialize_adc_use_internal_1V65_vref:
+    mov	    REF0CN, #1Ch	    ;; Set internal 1.65V as reference on 1S. Enable temp sensor and bias
+    sjmp    initialize_adc_vref_selected
+initialize_adc_use_vdd_3V3_vref:
+    mov     REF0CN, #0Ch        ;; Set vdd (3.3V) as reference on 2S+. Enable temp sensor and bias
+
+initialize_adc_vref_selected:
+    IF MCU_TYPE == 0
+        mov	ADC0CF, #59h		;; ADC clock 2MHz, PGA gain 1
+    ELSEIF MCU_TYPE == 1
+        mov	ADC0CF, #0B9h		;; ADC clock 2MHz, PGA gain 1
+    ENDIF
+ELSEIF MCU_TYPE == 2
+    mov	CLKGRP0, #18h			;; Enable SAR clock, at 12MHz
+    mov	ADC0CF1, #0Ah			;; 800ns tracking time
+    mov	ADC0CF2, #2Fh			;; 1.65V reference
+ENDIF
+
+    mov	ADC0MX, #10h				;; Select temp sensor input
+IF MCU_TYPE < 2
+    mov	ADC0CN0, #80h			;; ADC enabled
+    mov	ADC0CN1, #01h			;; Common mode buffer enabled
+ELSEIF MCU_TYPE == 2
+    mov	ADC0CN0, #85h			;; ADC enabled (gain 0.5, temp sensor enabled)
+    mov	ADC0CN1, #20h			;; 10bit mode
+ENDIF
 ENDM
 
 Start_Adc MACRO
-	IF MCU_48MHZ < 2
-		mov	ADC0CN0, #90h			;; Initiate conversion
-	ELSEIF MCU_48MHZ == 2
-		mov	ADC0CN0, #95h			;; Initiate conversion (gain 0.5, temp sensor enabled)
-	ENDIF
+IF MCU_TYPE < 2
+    mov	ADC0CN0, #90h			;; Initiate conversion
+ELSEIF MCU_TYPE == 2
+    mov	ADC0CN0, #95h			;; Initiate conversion (gain 0.5, temp sensor enabled)
+ENDIF
 ENDM
 
 Stop_Adc MACRO

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 	$(eval _ESC			:= $(1))
 	$(eval _ESC_INT		:= $(shell printf "%d" "'${_ESC}"))
 	$(eval _ESCNO		:= $(shell echo $$(( $(_ESC_INT) - 65 + 1))))
-	$(eval _MCU_48MHZ	:= $(subst L,0,$(subst H,1,$(subst X,2,$(2)))))
+	$(eval _MCU_TYPE	:= $(subst L,0,$(subst H,1,$(subst X,2,$(2)))))
 	$(eval _DEADTIME	:= $(3))
 	$(eval _PWM_FREQ	:= $(subst 24,0,$(subst 48,1,$(subst 96,2,$(4)))))
 	$$(eval _LST		:= $$(patsubst %.OBJ,%.LST,$$@))
@@ -71,7 +71,7 @@ $(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 	@echo "AX51 : $$@"
 	@$(AX51) $(ASM_SRC) \
 		"DEFINE(ESCNO=$(_ESCNO)) " \
-		"DEFINE(MCU_48MHZ=$(_MCU_48MHZ)) "\
+		"DEFINE(MCU_TYPE=$(_MCU_TYPE)) "\
 		"DEFINE(DEADTIME=$(_DEADTIME)) "\
 		"DEFINE(PWM_FREQ=$(_PWM_FREQ)) "\
 		"OBJECT($$@) "\

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,7 +2,7 @@
 source_path=$(dirname $(pwd))
 
 usage() {
-  echo "Usage: $0 [-l <A-W>] [-m <H|L>] [-d <integer>] [-p <24|48|96>]" 1>&2
+  echo "Usage: $0 [-l <A-W>] [-m <X|H|L>] [-d <integer>] [-p <24|48|96>]" 1>&2
   exit 1
 }
 


### PR DESCRIPTION
Added parameter to choose power rating so ADC has a stable reference on BB21 targets when no external voltage regulator exists (basically on 1S targets)

The new parameter is power rating. It has been allocated just after beacon delay parameter. It is of type byte, and has two possible values: 1 for 1S and 2 for 2S or higher.

I apologize that I also updated MCU_48MHZ identifier to MCU_TYPE for clarity. It is not the target of this commit, but I thought it would be convenient.

I have tested it on 1S BB21, 1S BB51 and 3S BB21