### PR TITLE
Implemented diagnostics on status and demag metric frames

### DIFF
--- a/Bluejay.asm
+++ b/Bluejay.asm
@@ -151,7 +151,7 @@ DEFAULT_PGM_BEACON_STRENGTH		EQU	80	; 0..255
 DEFAULT_PGM_BEACON_DELAY			EQU	4	; 1=1m		2=2m			3=5m			4=10m		5=Infinite
 DEFAULT_PGM_ENABLE_TEMP_PROT		EQU	7	; 0=Disabled	1=80C	2=90C	3=100C	4=110C	5=120C	6=130C	7=140C
 
-DEFAULT_PGM_POWER_RATING		EQU	1	; 1=1S, 2=2S+
+DEFAULT_PGM_POWER_RATING		EQU	2	; 1=1S, 2=2S+
 
 DEFAULT_PGM_BRAKE_ON_STOP		EQU	0	; 1=Enabled	0=Disabled
 DEFAULT_PGM_LED_CONTROL			EQU	0	; Byte for LED control. 2 bits per LED, 0=Off, 1=On
@@ -185,6 +185,9 @@ Flags0:					DS	1			; State flags. Reset upon motor_start
 Flag_Startup_Phase			BIT	Flags0.0		; Set when in startup phase
 Flag_Initial_Run_Phase		BIT	Flags0.1		; Set when in initial run phase (or startup phase), before synchronized run is achieved.
 Flag_Motor_Dir_Rev			BIT	Flags0.2		; Set if the current spinning direction is reversed
+Flag_Demag_Notify			BIT	Flags0.3		; Set when motor demag has been detected but still not notified
+Flag_Desync_Notify			BIT	Flags0.4		; Set when motor desync has been detected but still not notified
+Flag_Stall_Notify			BIT	Flags0.5		; Set when motor stall detected but still not notified
 
 Flags1:					DS	1			; State flags. Reset upon motor_start
 Flag_Timer3_Pending			BIT	Flags1.0		; Timer3 pending flag
@@ -227,6 +230,7 @@ Startup_Zc_Timeout_Cntd:		DS	1	; Startup zero cross timeout counter (decrementin
 Initial_Run_Rot_Cntd:		DS	1	; Initial run rotations counter (decrementing)
 Startup_Stall_Cnt:			DS	1	; Counts start/run attempts that resulted in stall. Reset upon a proper stop
 Demag_Detected_Metric:		DS	1	; Metric used to gauge demag event frequency
+Demag_Detected_Metric_Max:	DS	1	; Metric used to gauge demag event frequency
 Demag_Pwr_Off_Thresh:		DS	1	; Metric threshold above which power is cut
 Low_Rpm_Pwr_Slope:			DS	1	; Sets the slope of power increase for low rpm
 
@@ -1706,6 +1710,22 @@ set_pwm_limit_high_rpm_store:
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ;
 ; Scheduler
+;	Each step 32ms, cycle 256ms (8 steps)
+;
+;	ReqSch00:	- Steps even [0, 2, 4, 6]
+;	ReqSch01:		- Update temperature setpoint
+;	ReqSch02:		- [TELEMETRY] Send demag metric frame
+;	ReqSch03:	- Steps odd [1, 3, 5, 7]
+;	ReqSch04:		- Update temperature PWM limit
+;	ReqSch06:		- Case step 1
+;	ReqSch07:			- [TELEMETRY] Send status frame
+;	ReqSch08:		- Case step 3
+;	ReqSch09:			- [TELEMETRY] Send debug1 frame
+;	ReqSch10:		- Case step 5
+;	ReqSch11:			- [TELEMETRY] Send debug2 frame
+;	ReqSch12:		- Case step 7
+;	ReqSch13:			- [TELEMETRY] Send temperature frame
+;	ReqSch14:		- Start new ADC conversion
 ;
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 
@@ -1718,22 +1738,19 @@ scheduler_start:
 	; Increment Scheduler Counter
 	inc Scheduler_Counter
 
-;******************  128 ms scheduler *******************
-;***********  For PWM temperature limiting **************
-scheduler_128ms_switch_case:
-	; Apply 128ms mask to Scheduler_Counter (2 lowest bits)
+	; Choose between odd or even steps
 	mov A, Scheduler_Counter
-	anl A, #03h
+	jb ACC.0, scheduler_steps_odd
 
-scheduler_128ms_switch_case_32ms:
-	cjne A, #1, scheduler_128ms_switch_case_64ms
+scheduler_steps_even:
+	; ********************* UPDATE TEMPERATURE SETPOINT *****************
 
-	; Check temp protection enabled, and exit when protection is disabled
+	; Check temp protection enabled, and skip when protection is disabled
 	mov	A, Temp_Prot_Limit
-	jz	scheduler_1024ms_switch_case
+	jz	scheduler_steps_even_demag_metric_frame
 
-	; ******* UPDATE TEMPERATURE SETPOINT *******
-	mov	Temp_Pwm_Level_Setpoint, #255				; Remove setpoint
+	; Set setpoint maximum value
+	mov	Temp_Pwm_Level_Setpoint, #255
 
 	; Check TEMP_LIMIT in Base.inc and make calculations to understand temperature readings
 	; Is temperature reading below 256?
@@ -1743,191 +1760,213 @@ scheduler_128ms_switch_case_32ms:
 	; On BB51
 	;    - Using external voltage regulator and internal 1.65V as ADC reference -> ADC 10bit value corresponding to about 0ºC
 	mov	A, ADC0H									; Load temp hi
-	jz scheduler_1024ms_switch_case					; Temperature below 25ºC (on 2S+ (BB1, BB2)) and below 0ºC (on 1S (BB1, BB21), BB51) do not update setpoint
+	jz scheduler_steps_even_demag_metric_frame	; Temperature below 25ºC (on 2S+ (BB1, BB2)) and below 0ºC (on 1S (BB1, BB21), BB51) do not update setpoint
 
-	mov	A, ADC0L									; Load temp lo
+	mov	A, ADC0L								; Load temp lo
 
 	clr	C
-	subb	A, Temp_Prot_Limit						; Is temperature below first limit?
-	jc	scheduler_1024ms_switch_case				; Yes - Jump to next scheduler
+	subb	A, Temp_Prot_Limit					; Is temperature below first limit?
+	jc	scheduler_steps_even_demag_metric_frame	; Yes - Jump to next scheduler
 
-	mov	Temp_Pwm_Level_Setpoint, #200				; No - update pwm limit (about 80%)
+	mov	Temp_Pwm_Level_Setpoint, #200			; No - update pwm limit (about 80%)
 
-	subb	A, #(TEMP_LIMIT_STEP / 2)				; Is temperature below second limit
-	jc	scheduler_1024ms_switch_case				; Yes - Jump to next scheduler
+	subb	A, #(TEMP_LIMIT_STEP / 2)			; Is temperature below second limit
+	jc	scheduler_steps_even_demag_metric_frame	; Yes - Jump to next scheduler
 
-	mov	Temp_Pwm_Level_Setpoint, #150				; No - update pwm limit (about 60%)
+	mov	Temp_Pwm_Level_Setpoint, #150			; No - update pwm limit (about 60%)
 
-	subb	A, #(TEMP_LIMIT_STEP / 2)				; Is temperature below third limit
-	jc	scheduler_1024ms_switch_case				; Yes - Jump to next scheduler
+	subb	A, #(TEMP_LIMIT_STEP / 2)			; Is temperature below third limit
+	jc	scheduler_steps_even_demag_metric_frame	; Yes - Jump to next scheduler
 
-	mov	Temp_Pwm_Level_Setpoint, #100				; No - update pwm limit (about 40% allowing landing)
+	mov	Temp_Pwm_Level_Setpoint, #100			; No - update pwm limit (about 40% allowing landing)
 
-	subb	A, #(TEMP_LIMIT_STEP / 2)				; Is temperature below final limit
-	jc	scheduler_1024ms_switch_case				; Yes - Jump to next scheduler
+	subb	A, #(TEMP_LIMIT_STEP / 2)			; Is temperature below final limit
+	jc	scheduler_steps_even_demag_metric_frame	; Yes - Jump to next scheduler
 
-	mov	Temp_Pwm_Level_Setpoint, #50				; No - update pwm limit (about 20% forced landing)
+	mov	Temp_Pwm_Level_Setpoint, #50			; No - update pwm limit (about 20% forced landing)
 	; Zero pwm cannot be set because of set_pwm_limit algo restrictions
 	; Otherwise hard stuttering is produced
 
-	; Jump to next scheduler
-	sjmp scheduler_1024ms_switch_case
+scheduler_steps_even_demag_metric_frame:
+	; ********************* [TELEMETRY] SEND DEMAG METRIC FRAME *****************
+	mov Ext_Telemetry_L, Demag_Detected_Metric	; Set telemetry low value to demag metric data
+	mov Ext_Telemetry_H, #0Ch					; Set telemetry high value to demag metric frame ID
 
-scheduler_128ms_switch_case_64ms:
-	cjne A, #2, scheduler_128ms_switch_case_96ms
+	; No more work to do
+	jmp scheduler_exit
+
+scheduler_steps_odd:
+	; ********************* UPDATE TEMPERATURE PWM LIMIT *****************
 
 	; Check temp protection enabled, and exit when protection is disabled
 	mov	A, Temp_Prot_Limit
-	jz	scheduler_1024ms_switch_case
-
-	; Update PWM limit
+	jz	scheduler_steps_odd_choose_step
 
 	; pwm limit is updated one unit at a time to avoid abrupt pwm changes
-	; resulting in current spikes
+	; resulting in current spikes, that may damage motor/esc
 	; Compare pwm limit to setpoint
 	clr C
 	mov	A, Pwm_Limit
 	subb A, Temp_Pwm_Level_Setpoint
-	jz scheduler_1024ms_switch_case					; pwm limit == setpoint -> next
-	jc scheduler_128ms_temp_update_pwm_limit_inc	; pwm limit < setpoint -> increase pwm limit
+	jz scheduler_steps_odd_choose_step				; pwm limit == setpoint -> next
+	jc scheduler_steps_odd_temp_pwm_limit_inc		; pwm limit < setpoint -> increase pwm limit
 
-scheduler_128ms_temp_update_pwm_limit_dec:
+scheduler_steps_odd_temp_pwm_limit_dec:
 	; Decrease pwm limit
-	mov A, Pwm_Limit
-	jz scheduler_1024ms_switch_case					; pwm limit is 0 -> Exit
 	dec Pwm_Limit
 
-	; Jump to next scheduler
-	sjmp scheduler_1024ms_switch_case
+	; Now run speciffic odd scheduler step
+	sjmp scheduler_steps_odd_choose_step
 
-scheduler_128ms_temp_update_pwm_limit_inc:
+scheduler_steps_odd_temp_pwm_limit_inc:
 	; Increase pwm limit
-	mov A, Pwm_Limit
-	inc A
-	jz ($+4)
 	inc Pwm_Limit
 
-	; Jump to next scheduler
-	sjmp scheduler_1024ms_switch_case
+	; Now run speciffic odd scheduler step
 
-scheduler_128ms_switch_case_96ms:
-	cjne A, #3, scheduler_1024ms_switch_case
+scheduler_steps_odd_choose_step:
+	; Let A = Scheduler_Counter % 8, so A = [0 - 7] value
+	mov A, Scheduler_Counter
+	anl A, #07h
+
+scheduler_steps_odd_status_frame:
+	; ********************* [TELEMETRY] SEND STATUS FRAME *****************
+	cjne A, #1, scheduler_steps_odd_debug1_frame
+
+	; if (Demag_Detected_Metric_Max >= 120)
+	; 	stat.demagMetricMax = (Demag_Detected_Metric_Max - 120) / 9
+	; else
+	; 	stat.demagMetricMax = 0
+	clr	C
+	mov	A, Demag_Detected_Metric_Max
+	subb	A, #120						; 120: substract the minimum
+	jnc	scheduler_steps_odd_status_frame_max_load
+	clr	A
+	sjmp	scheduler_steps_odd_status_frame_max_loaded
+
+scheduler_steps_odd_status_frame_max_load:
+	mov	B, #9
+	div	AB								; Ranges: [0 - 135] / 9 == [0 - 15]
+
+scheduler_steps_odd_status_frame_max_loaded:
+	; Load flags
+	mov C, Flag_Demag_Notify
+	mov ACC.7, C
+	mov C, Flag_Desync_Notify
+	mov ACC.6, C
+	mov C, Flag_Stall_Notify
+	mov ACC.5, C
+
+	; Data loaded clear flags
+	clr	Flag_Demag_Notify
+	clr	Flag_Desync_Notify
+	clr	Flag_Stall_Notify
+
+	; Load status frame
+	mov Ext_Telemetry_L, A				; Set telemetry low value to status data
+	mov Ext_Telemetry_H, #0Eh			; Set telemetry high value to status frame ID
+
+	; Now restart ADC conversion
+	sjmp scheduler_steps_odd_restart_ADC
+
+scheduler_steps_odd_debug1_frame:
+	; ********************* [TELEMETRY] SEND DEBUG1 FRAME *****************
+	cjne A, #3, scheduler_steps_odd_debug2_frame
+
+	; Stub for debug 1
+	mov Ext_Telemetry_L, #088h			; Set telemetry low value
+	mov Ext_Telemetry_H, #08h			; Set telemetry high value to debug1 frame ID
+
+	; Now restart ADC conversion
+	sjmp scheduler_steps_odd_restart_ADC
+
+scheduler_steps_odd_debug2_frame:
+	; ********************* [TELEMETRY] SEND DEBUG2 FRAME *****************
+	cjne A, #5, scheduler_steps_odd_temperature_frame
+
+	; Stub for debug 2
+	mov Ext_Telemetry_L, #0AAh			; Set telemetry low value
+	mov Ext_Telemetry_H, #0Ah			; Set telemetry high value to debug2 frame ID
+
+	; Now restart ADC conversion
+	sjmp scheduler_steps_odd_restart_ADC
+
+scheduler_steps_odd_temperature_frame:
+	; ********************* [TELEMETRY] SEND TEMPERATURE FRAME *****************
+	cjne A, #7, scheduler_steps_odd_restart_ADC
+
+    ; ******************************************************************
+    ; Power rating only applies to BB21 because voltage references behave diferently
+    ; depending on an external voltage regulator is used or not.
+    ; For BB51 (MCU_TYPE == 2) 1s power rating code path is mandatory
+    ; ******************************************************************
+IF MCU_TYPE < 2
+    mov Temp1, #Pgm_Power_Rating
+    cjne @Temp1, #01h, scheduler_steps_odd_temperature_frame_power_rating_2s
+ENDIF
+
+scheduler_steps_odd_temperature_frame_power_rating_1s:
+    ; ******************************************************************
+    ; ON BB51 and BB1, BB2 at 1S, all using internal 1.65V ADC reference
+    ; ******************************************************************
+    mov A, ADC0H
+    jnz scheduler_steps_odd_temperature_frame_pr1s_temperature_above_0
+
+scheduler_steps_odd_temperature_frame_pr1s_temperature_below_0:
+    ; If Hi Byte is not 0x01 we are definetly below 0, thus
+    ; clamp to 0.
+    clr A
+    sjmp scheduler_steps_odd_temperature_frame_temp_load
+
+scheduler_steps_odd_temperature_frame_pr1s_temperature_above_0:
+    ; Prepare extended telemetry temperature value for next telemetry transmission
+    ; On BB51 they hi byte is always 1 if the temperature is above 0ºC.
+    ; In fact the value is 0x0114 at 0ºC, thus we ignore the hi byte and normalize
+    ; the low byte to
+    mov A, ADC0L
+    subb A, #14h
+    sjmp scheduler_steps_odd_temperature_frame_temp_load
+
+scheduler_steps_odd_temperature_frame_power_rating_2s:
+    ; *****************************************************
+    ; ON BB1, BB2 at more than 1S, using vdd V3.3 ADC reference
+    ; *****************************************************
+    ; Prepare extended telemetry temperature value for next telemetry transmission
+    ; Check value above or below 20ºC - this is an approximation ADCOH having a value
+    ; of 0x01 equals to around 22.5ºC.
+    mov A, ADC0H
+    jnz scheduler_steps_odd_temperature_frame_pr2s_temperature_above_20
+
+scheduler_steps_odd_temperature_frame_pr2s_temperature_below_20:
+    ; Value below 20ºC -> to code between 0-20
+    mov A, ADC0L
+    clr C
+    subb A, #(255 - 20)
+    jnc scheduler_steps_odd_temperature_frame_temp_load
+
+    ; Value below 0ºC -> clamp to 0
+    clr A
+    sjmp scheduler_steps_odd_temperature_frame_temp_load
+
+scheduler_steps_odd_temperature_frame_pr2s_temperature_above_20:
+    ; Value above 20ºC -> to code between 20-255
+    mov A, ADC0L                        ; This is an approximation: 9 ADC steps @10 Bit are 10 degrees
+    add A, #20
+
+scheduler_steps_odd_temperature_frame_temp_load:
+	mov Ext_Telemetry_L, A				; Set telemetry low value with temperature data
+	mov Ext_Telemetry_H, #02h			; Set telemetry high value on first repeated dshot coding partition
+
+	; Now restart ADC conversion
+
+scheduler_steps_odd_restart_ADC:
+	; ********************* START NEW ADC CONVERSION *****************
 
 	; Start a new ADC conversion so after 64ms it will be ready for stage 2 og 128ms scheduler
 	Stop_Adc
 	Start_Adc
 
-	; Continue on next scheduler
-
-
-
-
-;****************** 1024 ms scheduler *******************
-;************ For Extended Dshot Telemetry **************
-scheduler_1024ms_switch_case:
-	; Return if extended telemetry is disabled
-	jnb Flag_Ext_Tele, scheduler_exit
-
-	; Apply 1s mask to Scheduler_Counter (5 lowest bits)
-	mov A, Scheduler_Counter
-	anl A, #01Fh
-
-
-scheduler_1024ms_switch_case_128ms:
-	cjne A, #4, scheduler_1024ms_switch_case_256ms
-
-	; ******************************************************************
-	; Power rating only applies to BB21 because voltage references behave diferently
-	; depending on an external voltage regulator is used or not.
-	; For BB51 (MCU_TYPE == 2) 1s power rating code path is mandatory
-	; ******************************************************************
-IF MCU_TYPE < 2
-	mov Temp1, #Pgm_Power_Rating
-    cjne @Temp1, #01h, scheduler_1024ms_power_rating_2s
-ENDIF
-
-scheduler_1024ms_power_rating_1s:
-	; ******************************************************************
-	; ON BB51 and BB1, BB2 at 1S, all using internal 1.65V ADC reference
-	; ******************************************************************
-	mov A, ADC0H
-	jnz scheduler_1024ms_pr1s_do_extended_telemetry_temp_above_0
-
-scheduler_1024ms_pr1s_do_extended_telemetry_temp_below_0:
-	; If Hi Byte is not 0x01 we are definetly below 0, thus
-	; clamp to 0.
-	clr A
-	sjmp scheduler_1024ms_do_extended_telemetry_temp_load
-
-scheduler_1024ms_pr1s_do_extended_telemetry_temp_above_0:
-	; Prepare extended telemetry temperature value for next telemetry transmission
-	; On BB51 they hi byte is always 1 if the temperature is above 0ºC.
-	; In fact the value is 0x0114 at 0ºC, thus we ignore the hi byte and normalize
-	; the low byte to
-	mov A, ADC0L
-	subb A, #14h
-	sjmp scheduler_1024ms_do_extended_telemetry_temp_load
-
-scheduler_1024ms_power_rating_2s:
-	; *****************************************************
-	; ON BB1, BB2 at more than 1S, using vdd V3.3 ADC reference
-	; *****************************************************
-	; Prepare extended telemetry temperature value for next telemetry transmission
-	; Check value above or below 20ºC - this is an approximation ADCOH having a value
-	; of 0x01 equals to around 22.5ºC.
-	mov A, ADC0H
-	jnz scheduler_1024ms_pr2s_do_extended_telemetry_temp_above_20
-
-scheduler_1024ms_pr2s_do_extended_telemetry_temp_below_20:
-	; Value below 20ºC -> to code between 0-20
-	mov A, ADC0L
-	clr C
-	subb A, #(255 - 20)
-	jnc scheduler_1024ms_do_extended_telemetry_temp_load
-
-	; Value below 0ºC -> clamp to 0
-	clr A
-	sjmp scheduler_1024ms_do_extended_telemetry_temp_load
-
-scheduler_1024ms_pr2s_do_extended_telemetry_temp_above_20:
-	; Value above 20ºC -> to code between 20-255
-	mov A, ADC0L						; This is an approximation: 9 ADC steps @10 Bit are 10 degrees
-	add A, #20
-
-scheduler_1024ms_do_extended_telemetry_temp_load:
-	mov Ext_Telemetry_L, A				; Set telemetry low value with temperature data
-	mov Ext_Telemetry_H, #02h			; Set telemetry high value on first repeated dshot coding partition
-
-	; Exit switch case
-	sjmp scheduler_exit
-
-
-scheduler_1024ms_switch_case_256ms:
-	cjne A, #8, scheduler_1024ms_switch_case_384ms
-
-	; Stub for debug 0
-	mov Ext_Telemetry_L, #088h			; Set telemetry low value to dummy value
-	mov Ext_Telemetry_H, #08h			; Set telemetry high value on first repeated dshot coding partition
-
-	sjmp scheduler_exit
-
-scheduler_1024ms_switch_case_384ms:
-	cjne A, #12, scheduler_1024ms_switch_case_512ms
-
-	; Stub for debug 1
-	mov Ext_Telemetry_L, #0AAh			; Set telemetry low value to dummy value
-	mov Ext_Telemetry_H, #0Ah			; Set telemetry high value on first repeated dshot coding partition
-
-	sjmp scheduler_exit
-
-scheduler_1024ms_switch_case_512ms:
-	cjne A, #16, scheduler_exit
-
-	; Stub for debug 2
-	mov Ext_Telemetry_L, #0CCh			; Set telemetry low value with temperature data
-	mov Ext_Telemetry_H, #0Ch			; Set telemetry high value on first repeated dshot coding partition
-
-	; exit
+	; Nothing else to do
 
 scheduler_exit:
 	ret
@@ -2726,9 +2765,13 @@ wait_for_comm:
 	mov	B, #7
 	mul	AB						; Multiply by 7
 
-	jnb	Flag_Demag_Detected, ($+4)	; Add new value for current demag status
+	jnb	Flag_Demag_Detected, wait_for_comm_demag_event_added
+	; Add new value for current demag status
 	inc	B
+	; Signal demag
+	setb	Flag_Demag_Notify
 
+wait_for_comm_demag_event_added:
 	mov	C, B.0					; Divide by 8
 	rrc	A
 	mov	C, B.1
@@ -2741,10 +2784,22 @@ wait_for_comm:
 	jnc	($+5)
 	mov	Demag_Detected_Metric, #120
 
+	; Update demag metric max
 	clr	C
-	mov	A, Demag_Detected_Metric		; Check demag metric
+	mov	A, Demag_Detected_Metric
+	subb	A, Demag_Detected_Metric_Max
+	jc	wait_for_comm_demag_metric_max_updated
+	mov	Demag_Detected_Metric_Max, Demag_Detected_Metric
+
+wait_for_comm_demag_metric_max_updated:
+	; Check demag metric
+	clr	C
+	mov	A, Demag_Detected_Metric
 	subb	A, Demag_Pwr_Off_Thresh
 	jc	wait_for_comm_wait
+
+	; Signal desync
+	setb	Flag_Desync_Notify;
 
 	; Cut power if many consecutive demags. This will help retain sync during hard accelerations
 	All_Pwm_Fets_Off
@@ -4073,6 +4128,9 @@ setup_dshot:
 	jnb	Flag_Rcp_DShot_Inverted, ($+6)
 	mov	IT01CF, #(08h + (RTX_PIN SHL 4) + RTX_PIN) ; Route RCP input to Int0/1, with Int0 inverted
 
+	clr	Flag_Demag_Notify			; Clear motor events
+	clr	Flag_Desync_Notify
+	clr	Flag_Stall_Notify
 	clr	Flag_Telemetry_Pending		; Clear DShot telemetry flag
 	clr	Flag_Ext_Tele				; Clear extended telemetry enabled flag
 
@@ -4241,6 +4299,7 @@ motor_start:
 	mov	Flags0, A					; Clear run time flags
 	mov	Flags1, A
 	mov	Demag_Detected_Metric, A		; Clear demag metric
+	mov	Demag_Detected_Metric_Max, A	; Clear demag metric max
 
 	call	wait1ms
 
@@ -4544,12 +4603,15 @@ ENDIF
 	; Check if RCP is zero, then it is a normal stop or signal timeout
 	jb	Flag_Rcp_Stop, exit_run_mode_no_stall
 
+	; Signal stall
+	setb	Flag_Stall_Notify
+
 	clr	C						; Otherwise - it's a stall
 	mov	A, Startup_Stall_Cnt
 	subb	A, #4					; Maximum consecutive stalls
 	jnc	exit_run_mode_stall_done
 
-	call	wait100ms					; Wait for a bit between stall restarts
+	call	wait100ms				; Wait for a bit between stall restarts
 	ljmp	motor_start				; Go back and try starting motors again
 
 exit_run_mode_stall_done:


### PR DESCRIPTION
Relevant features:
- **Scheduler rewritten**
-- demag metric frame (0x0C) rate **64ms**
-- temperature frame (0x02) rate **256ms**
-- status frame (0x0E) rate **256ms**
-- debug1 frame (0x08) rate **256ms**
-- debug2 frame (0x0A) rate **256ms**
- **Status frame updated** (0x0E)
-- Added demag event on bit 7
-- Added desync event on bit 6
-- Added stall event on bit 5
-- Added mag demag metric on bits [3-0]
-  **Demag metric frame added** (0x0C)
-- Replaces debug3 frame
-- Publishes Demag_Detected_Metric value

The spec has been updated in the Betaflight pr https://github.com/betaflight/betaflight/pull/12170