### PR TITLE
Bugfix/reduce scheduler timebase

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -207,7 +207,7 @@ Flags2: DS 1                            ; State flags. NOT reset upon motor_star
     ; BIT    Flags2.0
     Flag_Pgm_Dir_Rev BIT Flags2.1       ; Set if the programmed direction is reversed
     Flag_Pgm_Bidir BIT Flags2.2         ; Set if the programmed control mode is bidirectional operation
-    Flag_32ms_Elapsed BIT Flags2.3      ; Set when timer2 interrupt is triggered
+    Flag_16ms_Elapsed BIT Flags2.3      ; Set when timer2 interrupt is triggered
     Flag_Ext_Tele BIT Flags2.4          ; Set if Extended DHOT telemetry is enabled
     Flag_Rcp_Stop BIT Flags2.5          ; Set if the RC pulse value is zero or if timeout occurs
     Flag_Rcp_Dir_Rev BIT Flags2.6       ; RC pulse direction in bidirectional mode

--- a/src/Layouts/Base.inc
+++ b/src/Layouts/Base.inc
@@ -368,6 +368,11 @@ ENDM
 Stop_Adc MACRO
 ENDM
 
+Restart_Adc MACRO
+    Stop_Adc
+    Start_Adc
+ENDM
+
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; LEDs
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -260,6 +260,7 @@ t1_int_not_bidir:
     mov  A, Temp4
     rrc  A
 
+    ; From here Temp5/Temp4 should be at most 1999 (4095-96) / 2
     ; Scale from 2000 to 2048
     add  A, Temp3
     mov  Temp4, A
@@ -524,7 +525,7 @@ t1_int_exit_no_int:
 ; Timer2 interrupt routine
 ;
 ; Update RC pulse timeout and stop counters
-; Happens every 32ms
+; Happens every 32ms before arming and every 16 ms after arming
 ;
 ; Requirements: No PSW instructions or Temp registers
 ;
@@ -533,7 +534,7 @@ t2_int:
     push ACC
     clr  TMR2CN0_TF2H                   ; Clear interrupt flag
     inc  Timer2_X                       ; Increment extended byte
-    setb Flag_32ms_Elapsed              ; Set 32ms elapsed flag
+    setb Flag_16ms_Elapsed              ; Set 16ms elapsed flag
 
     ; Check RC pulse timeout counter
     mov  A, Rcp_Timeout_Cntd            ; RC pulse timeout count zero?

--- a/src/Modules/Scheduler.asm
+++ b/src/Modules/Scheduler.asm
@@ -227,8 +227,7 @@ scheduler_steps_odd_status_frame_max_loaded:
     mov  Ext_Telemetry_H, #0Eh          ; Set telemetry high value to status frame ID
 
     ; Now restart ADC conversion
-    Stop_Adc
-    Start_Adc
+    Restart_Adc
 
     ; Nothing else to do
     ret
@@ -244,8 +243,7 @@ scheduler_steps_odd_debug1_frame:
     mov  Ext_Telemetry_H, #08h          ; Set telemetry high value to debug1 frame ID
 
     ; Now restart ADC conversion
-    Stop_Adc
-    Start_Adc
+    Restart_Adc
 
     ; Nothing else to do
     ret
@@ -261,8 +259,7 @@ scheduler_steps_odd_debug2_frame:
     mov  Ext_Telemetry_H, #0Ah          ; Set telemetry high value to debug2 frame ID
 
     ; Now restart ADC conversion
-    Stop_Adc
-    Start_Adc
+    Restart_Adc
 
     ; Nothing else to do
     ret
@@ -347,8 +344,7 @@ scheduler_steps_odd_restart_ADC:
 ; START NEW ADC CONVERSION
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
     ; Now restart ADC conversion
-    Stop_Adc
-    Start_Adc
+    Restart_Adc
 
     ; Nothing else to do
     ret


### PR DESCRIPTION
This pr reduces the scheduler timebase from 16ms to 128ms to interfere the minimum with commutation.
t2_int triggers every 32ms before arming. After arming sysclk is increased from 24.5Mhz to 49Mhz, so timer2 interrupt triggers every 16ms instead of 32ms.
As it is not really necessary to run the scheduler so fast (it is in charge of prepare telemetry frames, and updates pwm limit based on temperature) it is better to reduce its frequency of operation to 128ms, instead 16ms to avoid causing trouble on commutation.