### PR TITLE
Deprecate/dithering

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -169,7 +169,6 @@ DEFAULT_PGM_LED_CONTROL EQU 0           ; Byte for LED control. 2 bits per LED,0
 
 DEFAULT_PGM_STARTUP_POWER_MIN EQU 51    ; 0..255 => (1000..1125 Throttle): value * (1000 / 2047) + 1000
 DEFAULT_PGM_STARTUP_BEEP EQU 1          ; 0=Short beep,1=Melody
-DEFAULT_PGM_DITHERING EQU 0             ; 0=Disabled,1=Enabled
 
 DEFAULT_PGM_STARTUP_POWER_MAX EQU 25    ; 0..255 => (1000..2000 Throttle): Maximum startup power
 DEFAULT_PGM_BRAKING_STRENGTH EQU 255    ; 0..255 => 0..100 % Braking
@@ -225,13 +224,13 @@ Flags2: DS 1                            ; State flags. NOT reset upon motor_star
 
 Flags3: DS 1                            ; State flags. NOT reset upon motor_start
     Flag_Telemetry_Pending BIT Flags3.0 ; DShot telemetry data packet is ready to be sent
-    Flag_Dithering BIT Flags3.1         ; PWM dithering enabled
-    Flag_Had_Signal BIT Flags3.2        ; Used to detect reset after having had a valid signal
-    Flag_User_Reverse_Requested BIT Flags3.3 ; It is set when user request to reverse motors in turtle mode
+    Flag_Had_Signal BIT Flags3.1        ; Used to detect reset after having had a valid signal
+    Flag_User_Reverse_Requested BIT Flags3.2 ; It is set when user request to reverse motors in turtle mode
 
 
 Tlm_Data_L: DS 1                        ; DShot telemetry data (lo byte)
 Tlm_Data_H: DS 1                        ; DShot telemetry data (hi byte)
+
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Direct addressing data segment
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
@@ -302,7 +301,7 @@ ISEG AT 080h                            ; The variables below must be in this se
 _Pgm_Gov_P_Gain: DS 1                   ;
 Pgm_Startup_Power_Min: DS 1             ; Minimum power during startup phase
 Pgm_Startup_Beep: DS 1                  ; Startup beep melody on/off
-Pgm_Dithering: DS 1                     ; Enable PWM dithering
+_Pgm_Dithering: DS 1                    ;
 Pgm_Startup_Power_Max: DS 1             ; Maximum power (limit) during startup (and starting initial run phase)
 _Pgm_Rampup_Slope: DS 1                 ;
 Pgm_Rpm_Power_Slope: DS 1               ; Low RPM power protection slope (factor)
@@ -340,11 +339,8 @@ Pgm_LED_Control: DS 1                   ; LED control
 Pgm_Power_Rating: DS 1                  ; Power rating
 Pgm_Safety_Arm: DS  1                   ; Various flag settings: bit 0 is require edt enable to arm
 
-ISEG AT 0B0h
-Stack: DS 16                            ; Reserved stack space
-
 ISEG AT 0C0h
-Dithering_Patterns: DS 16               ; Bit patterns for pwm dithering
+Stack: DS 16                            ; Reserved stack space
 
 ISEG AT 0D0h
 Temp_Storage: DS 48                     ; Temporary storage (internal memory)
@@ -365,7 +361,7 @@ Eep_Layout_Revision: DB EEPROM_LAYOUT_REVISION ; EEPROM layout revision number
 _Eep_Pgm_Gov_P_Gain: DB 0FFh
 Eep_Pgm_Startup_Power_Min: DB DEFAULT_PGM_STARTUP_POWER_MIN
 Eep_Pgm_Startup_Beep: DB DEFAULT_PGM_STARTUP_BEEP
-Eep_Pgm_Dithering: DB DEFAULT_PGM_DITHERING
+_Eep_Pgm_Dithering: DB 000h
 Eep_Pgm_Startup_Power_Max: DB DEFAULT_PGM_STARTUP_POWER_MAX
 _Eep_Pgm_Rampup_Slope: DB 0FFh
 Eep_Pgm_Rpm_Power_Slope: DB DEFAULT_PGM_RPM_POWER_SLOPE ; EEPROM copy of programmed rpm power slope (formerly startup power)

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -414,36 +414,6 @@ ELSEIF PWM_BITS_H == PWM_8_BIT
     mov  Temp3, #0
 ENDIF
 
-; 11-bit effective dithering of 8/9/10-bit pwm
-IF PWM_BITS_H == PWM_8_BIT or PWM_BITS_H == PWM_9_BIT or PWM_BITS_H == PWM_10_BIT
-    jnb  Flag_Dithering, t1_int_set_pwm
-
-    mov  A, Temp4                       ; 11-bit low byte
-    cpl  A
-    anl  A, #((1 SHL (3 - PWM_BITS_H)) - 1); Get index into dithering pattern table
-
-    add  A, #Dithering_Patterns
-    mov  Temp1, A                       ; Reuse DShot pwm pointer since it is not currently in use.
-    mov  A, @Temp1                      ; Retrieve pattern
-    rl   A                              ; Rotate pattern
-    mov  @Temp1, A                      ; Store pattern
-
-    jnb  ACC.0, t1_int_set_pwm          ; Increment if bit is set
-
-    mov  A, Temp2
-    add  A, #1
-    mov  Temp2, A
-    jnz  t1_int_set_pwm
-IF PWM_BITS_H != PWM_8_BIT
-    mov  A, Temp3
-    addc A, #0
-    mov  Temp3, A
-    jnb  ACC.PWM_BITS_H, t1_int_set_pwm
-    dec  Temp3                          ; Reset on overflow
-ENDIF
-    dec  Temp2
-ENDIF
-
 t1_int_set_pwm:
 ; Set PWM registers
 IF DEADTIME != 0

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -33,7 +33,7 @@ set_default_parameters:
     mov  @Temp1, #0FFh                  ; _Pgm_Gov_P_Gain
     imov Temp1, #DEFAULT_PGM_STARTUP_POWER_MIN ; Pgm_Startup_Power_Min
     imov Temp1, #DEFAULT_PGM_STARTUP_BEEP ; Pgm_Startup_Beep
-    imov Temp1, #DEFAULT_PGM_DITHERING  ; Pgm_Dithering
+    imov Temp1, #000h                   ; _Pgm_Dithering
     imov Temp1, #DEFAULT_PGM_STARTUP_POWER_MAX ; Pgm_Startup_Power_Max
     imov Temp1, #0FFh                   ; _Pgm_Rampup_Slope
     imov Temp1, #DEFAULT_PGM_RPM_POWER_SLOPE ; Pgm_Rpm_Power_Slope
@@ -199,42 +199,8 @@ ELSEIF PWM_BITS_H == PWM_8_BIT
     mov  Pwm_Braking_H, #0
     mov  Pwm_Braking_L, A
 ENDIF
-    cjne @Temp1, #0FFh, decode_pwm_dithering
+    cjne @Temp1, #0FFh, decode_end
     mov  Pwm_Braking_L, #0FFh           ; Apply full braking if setting is max
 
-;**** **** **** **** **** **** **** **** **** **** **** **** ****
-;
-; Dithering
-;
-; Depending on resolution, different dithering patterns are available.
-;
-;**** **** **** **** **** **** **** **** **** **** **** **** ****
-
-decode_pwm_dithering:
-    mov  Temp1, #Pgm_Dithering          ; Read programmed dithering setting
-    mov  A, @Temp1
-    add  A, #0FFh                       ; Carry set if A is not zero
-    mov  Flag_Dithering, C              ; Set dithering enabled
-
-IF PWM_BITS_H == PWM_10_BIT             ; Initialize pwm dithering bit patterns
-    mov  Temp1, #Dithering_Patterns     ; 1-bit dithering (10-bit to 11-bit)
-    mov  @Temp1, #00h                   ; 00000000
-    imov Temp1, #55h                    ; 01010101
-ELSEIF PWM_BITS_H == PWM_9_BIT
-    mov  Temp1, #Dithering_Patterns     ; 2-bit dithering (9-bit to 11-bit)
-    mov  @Temp1, #00h                   ; 00000000
-    imov Temp1, #11h                    ; 00010001
-    imov Temp1, #55h                    ; 01010101
-    imov Temp1, #77h                    ; 01110111
-ELSEIF PWM_BITS_H == PWM_8_BIT
-    mov  Temp1, #Dithering_Patterns     ; 3-bit dithering (8-bit to 11-bit)
-    mov  @Temp1, #00h                   ; 00000000
-    imov Temp1, #01h                    ; 00000001
-    imov Temp1, #11h                    ; 00010001
-    imov Temp1, #25h                    ; 00100101
-    imov Temp1, #55h                    ; 01010101
-    imov Temp1, #5Bh                    ; 01011011
-    imov Temp1, #77h                    ; 01110111
-    imov Temp1, #7fh                    ; 01111111
-ENDIF
+decode_end:
     ret


### PR DESCRIPTION
Drop current dithering implementation because it depends on dshot speed, so dithering do not work the same when it is used at dshot 150 than when used at dshot 600. It neither is 11bit dithering because it only "adds" 1 extra bit of resolution, so when used with 96khz pwm frequency (8 bit) it would be a 9 bit dithering of sorts.