### PR TITLE
Feature/dynamic pwm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,11 @@ MCUS			= H
 LAYOUTS_X		= A B C
 MCUS_X		= X
 DEADTIMES		= 0 5 10 15 20 25 30 40 50 70 90 120
-PWM_FREQS		= 24 48 96
 
 # Example single target
 LAYOUT		?= A
 MCU			?= H
 DEADTIME	?= 5
-PWM			?= 24
 
 # Directory configuration
 OUTPUT_DIR	?= build
@@ -78,8 +76,8 @@ EFM8_LOAD_BAUD	?= 115200
 .NOTPARALLEL:
 
 define MAKE_OBJ
-OBJS += $(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ
-$(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
+OBJS += $(1)_$(2)_$(3)_$(VERSION).OBJ
+$(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 	$(eval _ESC			:= $(1))
 	$(eval _ESC_INT		:= $(shell printf "%d" "'${_ESC}"))
 	$(eval _ESCNO		:= $(shell echo $$(( $(_ESC_INT) - 65 + 1))))
@@ -88,7 +86,6 @@ $(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 
 	$(eval _MCU_TYPE	:= $(subst L,0,$(subst H,1,$(subst X,2,$(2)))))
 	$(eval _DEADTIME	:= $(3))
-	$(eval _PWM_FREQ	:= $(subst 24,0,$(subst 48,1,$(subst 96,2,$(4)))))
 	$$(eval _LST		:= $$(patsubst %.OBJ,%.LST,$$@))
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "AX51 : $$@"
@@ -96,13 +93,12 @@ $(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(4)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 		"DEFINE(ESCNO=$(_ESCNO)) " \
 		"DEFINE(MCU_TYPE=$(_MCU_TYPE)) "\
 		"DEFINE(DEADTIME=$(_DEADTIME)) "\
-		"DEFINE(PWM_FREQ=$(_PWM_FREQ)) "\
 		"OBJECT($$@) "\
 		"PRINT($$(_LST)) "\
 		"$(AX51_FLAGS)" > /dev/null 2>&1 || (grep -B 3 -E "\*\*\* (ERROR|WARNING)" $$(_LST); exit 1)
 endef
 
-SINGLE_TARGET_HEX = $(HEX_DIR)/$(LAYOUT)_$(MCU)_$(DEADTIME)_$(PWM)_$(VERSION).hex
+SINGLE_TARGET_HEX = $(HEX_DIR)/$(LAYOUT)_$(MCU)_$(DEADTIME)_$(VERSION).hex
 
 single_target : $(SINGLE_TARGET_HEX)
 
@@ -110,14 +106,12 @@ single_target : $(SINGLE_TARGET_HEX)
 $(foreach _l, $(LAYOUTS), \
 	$(foreach _m, $(MCUS), \
 		$(foreach _d, $(DEADTIMES), \
-			$(foreach _p, $(filter-out $(subst L,96,$(_m)), $(PWM_FREQS)), \
-				$(eval $(call MAKE_OBJ,$(_l),$(_m),$(_d),$(_p)))))))
+			$(eval $(call MAKE_OBJ,$(_l),$(_m),$(_d))))))
 
 $(foreach _l, $(LAYOUTS_X), \
 	$(foreach _m, $(MCUS_X), \
 		$(foreach _d, $(DEADTIMES), \
-			$(foreach _p, $(filter-out $(subst L,96,$(_m)), $(PWM_FREQS)), \
-				$(eval $(call MAKE_OBJ,$(_l),$(_m),$(_d),$(_p)))))))
+			$(eval $(call MAKE_OBJ,$(_l),$(_m),$(_d))))))
 
 HEX_TARGETS = $(OBJS:%.OBJ=$(HEX_DIR)/%.hex)
 
@@ -153,7 +147,7 @@ help:
 	@echo "Usage examples"
 	@echo "================================================================"
 	@echo "make all                                 # Build all targets"
-	@echo "make LAYOUT=A MCU=H DEADTIME=5 PWM=24    # Build a single target"
+	@echo "make LAYOUT=A MCU=H DEADTIME=5           # Build a single target"
 	@echo
 
 clean:

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -287,6 +287,7 @@ DShot_GCR_Start_Delay: DS 1
 Ext_Telemetry_L: DS 1                   ; Extended telemetry data to be sent
 Ext_Telemetry_H: DS 1
 Scheduler_Counter: DS 1                 ; Scheduler Heartbeat
+Throttle_48to24_Threshold: DS 1         ; Threshold to switch between 24 and 48khz
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Indirect addressing data segments

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -300,7 +300,7 @@ _Pgm_Dithering: DS 1                    ;
 Pgm_Startup_Power_Max: DS 1             ; Maximum power (limit) during startup (and starting initial run phase)
 _Pgm_Rampup_Slope: DS 1                 ;
 Pgm_Rpm_Power_Slope: DS 1               ; Low RPM power protection slope (factor)
-Pgm_Pwm_Freq: DS 1                      ; PWM frequency (temporary method for display)
+_Pgm_Pwm_Freq: DS 1                     ;
 Pgm_Direction: DS 1                     ; Rotation direction
 _Pgm_Input_Pol: DS 1                    ; Input PWM polarity
 Initialized_L_Dummy: DS 1               ; Place holder
@@ -361,7 +361,7 @@ _Eep_Pgm_Dithering: DB 000h
 Eep_Pgm_Startup_Power_Max: DB DEFAULT_PGM_STARTUP_POWER_MAX
 _Eep_Pgm_Rampup_Slope: DB 0FFh
 Eep_Pgm_Rpm_Power_Slope: DB DEFAULT_PGM_RPM_POWER_SLOPE ; EEPROM copy of programmed rpm power slope (formerly startup power)
-Eep_Pgm_Pwm_Freq: DB (24 SHL PWM_FREQ)  ; Temporary method for display
+_Eep_Pgm_Pwm_Freq: DB 0FFh
 Eep_Pgm_Direction: DB DEFAULT_PGM_DIRECTION ; EEPROM copy of programmed rotation direction
 _Eep__Pgm_Input_Pol: DB 0FFh
 Eep_Initialized_L: DB 055h              ; EEPROM initialized signature (lo byte)

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -146,6 +146,7 @@ $include (Modules\Macros.asm)
 ; Programming defaults
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 DEFAULT_PGM_RPM_POWER_SLOPE EQU 9       ; 0=Off,1..13 (Power limit factor in relation to rpm)
+DEFAULT_PWM_FREQUENCY EQU 24            ; 24=24khz, 48=48khz, otherwise dynamic
 DEFAULT_PGM_COMM_TIMING EQU 4           ; 1=Low 2=MediumLow 3=Medium 4=MediumHigh 5=High
 DEFAULT_PGM_DEMAG_COMP EQU 2            ; 1=Disabled 2=Low 3=High
 DEFAULT_PGM_DIRECTION EQU 1             ; 1=Normal 2=Reversed 3=Bidir 4=Bidir rev
@@ -300,7 +301,7 @@ _Pgm_Dithering: DS 1                    ;
 Pgm_Startup_Power_Max: DS 1             ; Maximum power (limit) during startup (and starting initial run phase)
 _Pgm_Rampup_Slope: DS 1                 ;
 Pgm_Rpm_Power_Slope: DS 1               ; Low RPM power protection slope (factor)
-_Pgm_Pwm_Freq: DS 1                     ;
+Pgm_Pwm_Freq: DS 1                      ; PWM frequency
 Pgm_Direction: DS 1                     ; Rotation direction
 _Pgm_Input_Pol: DS 1                    ; Input PWM polarity
 Initialized_L_Dummy: DS 1               ; Place holder
@@ -361,7 +362,7 @@ _Eep_Pgm_Dithering: DB 000h
 Eep_Pgm_Startup_Power_Max: DB DEFAULT_PGM_STARTUP_POWER_MAX
 _Eep_Pgm_Rampup_Slope: DB 0FFh
 Eep_Pgm_Rpm_Power_Slope: DB DEFAULT_PGM_RPM_POWER_SLOPE ; EEPROM copy of programmed rpm power slope (formerly startup power)
-_Eep_Pgm_Pwm_Freq: DB 0FFh
+Eep_Pgm_Pwm_Freq: DB DEFAULT_PWM_FREQUENCY ; EEPROM copy of programmed pwm frequency
 Eep_Pgm_Direction: DB DEFAULT_PGM_DIRECTION ; EEPROM copy of programmed rotation direction
 _Eep__Pgm_Input_Pol: DB 0FFh
 Eep_Initialized_L: DB 055h              ; EEPROM initialized signature (lo byte)

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -129,20 +129,12 @@ ENDIF
 ; Select the FET dead time (or unselect for use with external batch compile file)
 ;DEADTIME            EQU    15    ; 20.4ns per step
 
-; Select the pwm frequency (or unselect for use with external batch compile file)
-;PWM_FREQ            EQU    0    ; 0=24, 1=48, 2=96 kHz
-
 PWM_CENTERED EQU DEADTIME > 0           ; Use center aligned pwm on ESCs with dead time
 
 IF MCU_TYPE == MCU_BB1
     IS_MCU_48MHZ EQU 0
 ELSE
     IS_MCU_48MHZ EQU 1
-ENDIF
-
-IF PWM_FREQ == PWM_24 or PWM_FREQ == PWM_48 or PWM_FREQ == PWM_96
-    ; Number of bits in pwm high byte
-    PWM_BITS_H EQU (2 + IS_MCU_48MHZ - PWM_CENTERED - PWM_FREQ)
 ENDIF
 
 $include (Modules\McuOffsets.asm)
@@ -174,6 +166,7 @@ DEFAULT_PGM_STARTUP_POWER_MAX EQU 25    ; 0..255 => (1000..2000 Throttle): Maxim
 DEFAULT_PGM_BRAKING_STRENGTH EQU 255    ; 0..255 => 0..100 % Braking
 
 DEFAULT_PGM_SAFETY_ARM EQU 0            ; EDT safety arm is disabled by default
+DEFAULT_48to24_THRESHOLD EQU 170        ; About 66% threshold to change between 48 and 24khz
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Temporary register definitions
@@ -238,7 +231,6 @@ DSEG AT 30h
 Rcp_Outside_Range_Cnt: DS 1             ; RC pulse outside range counter (incrementing)
 Rcp_Timeout_Cntd: DS 1                  ; RC pulse timeout counter (decrementing)
 Rcp_Stop_Cnt: DS 1                      ; Counter for RC pulses below stop value
-
 Beacon_Delay_Cnt: DS 1                  ; Counter to trigger beacon during wait for start
 Startup_Cnt: DS 1                       ; Startup phase commutations counter (incrementing)
 Startup_Zc_Timeout_Cntd: DS 1           ; Startup zero cross timeout counter (decrementing)
@@ -268,8 +260,10 @@ Wt_Comm_Start_H: DS 1                   ; Timer3 start point from zero cross to 
 Pwm_Limit: DS 1                         ; Maximum allowed pwm (8-bit)
 Pwm_Limit_By_Rpm: DS 1                  ; Maximum allowed pwm for low or high rpm (8-bit)
 Pwm_Limit_Beg: DS 1                     ; Initial pwm limit (8-bit)
-Pwm_Braking_L: DS 1                     ; Max Braking pwm (lo byte)
-Pwm_Braking_H: DS 1                     ; Max Braking pwm (hi byte)
+Pwm_Braking24_L: DS 1                   ; Max Braking @24khz pwm (lo byte)
+Pwm_Braking24_H: DS 1                   ; Max Braking @24khz pwm (hi byte)
+Pwm_Braking48_L: DS 1                   ; Max Braking @48khz pwm (lo byte)
+Pwm_Braking48_H: DS 1                   ; Max Braking @48khz pwm (hi byte)
 Temp_Prot_Limit: DS 1                   ; Temperature protection limit
 Temp_Pwm_Level_Setpoint: DS 1           ; PWM level setpoint
 Beep_Strength: DS 1                     ; Strength of beeps
@@ -286,7 +280,6 @@ DShot_Cmd_Cnt: DS 1                     ; DShot command count
 DShot_GCR_Pulse_Time_1: DS 1            ; Encodes binary: 1
 DShot_GCR_Pulse_Time_2: DS 1            ; Encodes binary: 01
 DShot_GCR_Pulse_Time_3: DS 1            ; Encodes binary: 001
-
 DShot_GCR_Pulse_Time_1_Tmp: DS 1
 DShot_GCR_Pulse_Time_2_Tmp: DS 1
 DShot_GCR_Pulse_Time_3_Tmp: DS 1
@@ -294,6 +287,7 @@ DShot_GCR_Start_Delay: DS 1
 Ext_Telemetry_L: DS 1                   ; Extended telemetry data to be sent
 Ext_Telemetry_H: DS 1
 Scheduler_Counter: DS 1                 ; Scheduler Heartbeat
+
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Indirect addressing data segments
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
@@ -337,7 +331,8 @@ _Pgm_Pwm_Dither: DS 1                   ; Output PWM dither
 Pgm_Brake_On_Stop: DS 1                 ; Braking when throttle is zero
 Pgm_LED_Control: DS 1                   ; LED control
 Pgm_Power_Rating: DS 1                  ; Power rating
-Pgm_Safety_Arm: DS  1                   ; Various flag settings: bit 0 is require edt enable to arm
+Pgm_Safety_Arm: DS 1                    ; Various flag settings: bit 0 is require edt enable to arm
+Pgm_48to24_Threshold: DS 1              ; Threshold to move between 48 and 24 khz PWM frequency
 
 ISEG AT 0C0h
 Stack: DS 16                            ; Reserved stack space
@@ -352,8 +347,8 @@ Temp_Storage: DS 48                     ; Temporary storage (internal memory)
 CSEG AT CSEG_EEPROM
 EEPROM_FW_MAIN_REVISION EQU 0           ; Main revision of the firmware
 EEPROM_FW_SUB_REVISION EQU 21           ; Sub revision of the firmware
-EEPROM_LAYOUT_REVISION EQU 207          ; Revision of the EEPROM layout
-EEPROM_B2_PARAMETERS_COUNT EQU 28       ; Number of parameters
+EEPROM_LAYOUT_REVISION EQU 208          ; Revision of the EEPROM layout
+EEPROM_B2_PARAMETERS_COUNT EQU 29       ; Number of parameters
 
 Eep_FW_Main_Revision: DB EEPROM_FW_MAIN_REVISION ; EEPROM firmware main revision number
 Eep_FW_Sub_Revision: DB EEPROM_FW_SUB_REVISION ; EEPROM firmware sub revision number
@@ -399,6 +394,8 @@ Eep_Pgm_Brake_On_Stop: DB DEFAULT_PGM_BRAKE_ON_STOP ; EEPROM copy of programmed 
 Eep_Pgm_LED_Control: DB DEFAULT_PGM_LED_CONTROL ; EEPROM copy of programmed LED control
 Eep_Pgm_Power_Rating: DB DEFAULT_PGM_POWER_RATING ; EEPROM copy of programmed power rating
 Eep_Pgm_Safety_Arm: DB DEFAULT_PGM_SAFETY_ARM ; Various flag settings: bit 0 is require edt enable to arm
+Eep_Pgm_48to24_Threshold: DB DEFAULT_48to24_THRESHOLD ; Threshold to move between 48 and 24 khz PWM frequency
+
 
 Eep_Dummy: DB 0FFh                      ; EEPROM address for safety reason
 CSEG AT CSEG_NAME

--- a/src/Modules/Common.asm
+++ b/src/Modules/Common.asm
@@ -225,11 +225,12 @@ Initialize_PCA MACRO
     mov  PCA0CN0, #40h                  ; PCA enabled
     mov  PCA0MD, #08h                   ; PCA clock is system clock
 
-    mov  PCA0PWM, #(80h + PWM_BITS_H)   ; Enable PCA auto-reload registers and set pwm cycle length (8-11 bits)
 
 IF PWM_CENTERED == 1
+    mov  PCA0PWM, #83h                  ; Enable PCA auto-reload registers and set pwm cycle length (11 bits) for 24khz
     mov  PCA0CENT, #07h                 ; Center aligned pwm
 ELSE
+    mov  PCA0PWM, #82h                  ; Enable PCA auto-reload registers and set pwm cycle length (10 bits) for 24khz
     mov  PCA0CENT, #00h                 ; Edge aligned pwm
 ENDIF
 ENDM

--- a/src/Modules/Enums.asm
+++ b/src/Modules/Enums.asm
@@ -39,15 +39,8 @@
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 
     ; Frequency
-    PWM_96 EQU 2
     PWM_48 EQU 1
     PWM_24 EQU 0
-
-    ; Resolution
-    PWM_11_BIT EQU 3
-    PWM_10_BIT EQU 2
-    PWM_9_BIT EQU 1
-    PWM_8_BIT EQU 0
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; DSHOT Commands

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -318,7 +318,7 @@ t1_int_stall_boost:
     mov  Temp5, #07h
 
 t1_int_startup_boosted:
-    ; Set 8-bit value
+    ; Calculate and store 8-bit scaled down rc pulse in Temp2
     mov  A, Temp4
     anl  A, #0F8h
     orl  A, Temp5                       ; Assumes Temp5 to be 3-bit (11-bit RC pulse)
@@ -358,22 +358,28 @@ t1_int_zero_rcp_checked_check_limit:
     clr  C
     mov  A, Temp6
     subb A, Temp2                       ; 8-bit rc pulse
-    jnc  t1_int_scale_pwm_resolution
+    jnc  t1_int_dynamic_pwm
 
-IF PWM_BITS_H == PWM_8_BIT              ; 8-bit pwm
+    ; Multiply limit by 8 for 11-bit pwm
     mov  A, Temp6
-    mov  Temp2, A
-ELSE
-    mov  A, Temp6                       ; Multiply limit by 8 for 11-bit pwm
     mov  B, #8
     mul  AB
+    ; Set limit
     mov  Temp4, A
     mov  Temp5, B
-ENDIF
 
-t1_int_scale_pwm_resolution:
-; Scale pwm resolution and invert (duty cycle is defined inversely)
-IF PWM_BITS_H == PWM_11_BIT
+t1_int_dynamic_pwm:
+    ; Dynamic PWM
+    clr C
+    mov A, Temp2
+    mov Temp1, #Pgm_48to24_Threshold
+    subb A, @Temp1
+    jnc t1_int_run_48khz
+
+IF PWM_CENTERED == 1
+t1_int_run_24khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; No deadtime and 24khz
     mov  A, Temp5
     cpl  A
     anl  A, #7
@@ -381,7 +387,15 @@ IF PWM_BITS_H == PWM_11_BIT
     mov  A, Temp4
     cpl  A
     mov  Temp2, A
-ELSEIF PWM_BITS_H == PWM_10_BIT
+
+    ; Set PCA to work at 24khz
+    mov  PCA0PWM, #83h
+
+    jmp t1_int_set_pwm
+
+t1_int_run_48khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 48khz
     clr  C
     mov  A, Temp5
     rrc  A
@@ -392,7 +406,61 @@ ELSEIF PWM_BITS_H == PWM_10_BIT
     rrc  A
     cpl  A
     mov  Temp2, A
-ELSEIF PWM_BITS_H == PWM_9_BIT
+
+    ; Set PCA to work at 48khz
+    mov  PCA0PWM, #82h
+ELSE
+t1_int_run_24khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 24khz
+    clr  C
+    mov  A, Temp5
+    rrc  A
+    cpl  A
+    anl  A, #3
+    mov  Temp3, A
+    mov  A, Temp4
+    rrc  A
+    cpl  A
+    mov  Temp2, A
+
+    ; Set PCA to work at 24khz
+    mov  PCA0PWM, #82h
+
+    ; Subtract dead time from normal pwm and store as damping PWM
+    ; Damping PWM duty cycle will be higher because numbers are inverted
+    clr  C
+    mov  A, Temp2                       ; Skew damping FET timing
+IF MCU_TYPE == MCU_BB1
+    subb A, #((DEADTIME + 1) SHR 1)
+ELSE
+    subb A, #(DEADTIME)
+ENDIF
+    mov  Temp4, A
+    mov  A, Temp3
+    subb A, #0
+    mov  Temp5, A
+    jnc  t1_int_max_braking_set_24khz
+
+    clr  A                              ; Set to minimum value
+    mov  Temp4, A
+    mov  Temp5, A
+    jmp t1_int_set_pwm                  ; Max braking is already zero - branch
+
+t1_int_max_braking_set_24khz:
+    clr  C
+    mov  A, Temp4
+    subb A, Pwm_Braking24_L
+    mov  A, Temp5
+    subb A, Pwm_Braking24_H             ; Is braking pwm more than maximum allowed braking?
+    jc   t1_int_set_pwm                 ; Yes - branch
+    mov  Temp4, Pwm_Braking24_L         ; No - set desired braking instead
+    mov  Temp5, Pwm_Braking24_H
+    jmp t1_int_set_pwm
+
+t1_int_run_48khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 48khz
     mov  B, Temp5
     mov  A, Temp4
     mov  C, B.0
@@ -407,16 +475,10 @@ ELSEIF PWM_BITS_H == PWM_9_BIT
     cpl  A
     anl  A, #1
     mov  Temp3, A
-ELSEIF PWM_BITS_H == PWM_8_BIT
-    mov  A, Temp2                       ; Temp2 already 8-bit
-    cpl  A
-    mov  Temp2, A
-    mov  Temp3, #0
-ENDIF
 
-t1_int_set_pwm:
-; Set PWM registers
-IF DEADTIME != 0
+    ; Set PCA to work at 48khz
+    mov  PCA0PWM, #81h
+
     ; Subtract dead time from normal pwm and store as damping PWM
     ; Damping PWM duty cycle will be higher because numbers are inverted
     clr  C
@@ -430,44 +492,36 @@ ENDIF
     mov  A, Temp3
     subb A, #0
     mov  Temp5, A
-    jnc  t1_int_max_braking_set
+    jnc  t1_int_max_braking_set_48khz
 
     clr  A                              ; Set to minimum value
     mov  Temp4, A
     mov  Temp5, A
-    sjmp t1_int_pwm_braking_set         ; Max braking is already zero - branch
+    sjmp t1_int_set_pwm                 ; Max braking is already zero - branch
 
-t1_int_max_braking_set:
+t1_int_max_braking_set_48khz:
     clr  C
     mov  A, Temp4
-    subb A, Pwm_Braking_L
+    subb A, Pwm_Braking48_L
     mov  A, Temp5
-    subb A, Pwm_Braking_H               ; Is braking pwm more than maximum allowed braking?
-    jc   t1_int_pwm_braking_set         ; Yes - branch
-    mov  Temp4, Pwm_Braking_L           ; No - set desired braking instead
-    mov  Temp5, Pwm_Braking_H
-
-t1_int_pwm_braking_set:
+    subb A, Pwm_Braking48_H             ; Is braking pwm more than maximum allowed braking?
+    jc   t1_int_set_pwm                 ; Yes - branch
+    mov  Temp4, Pwm_Braking48_L         ; No - set desired braking instead
+    mov  Temp5, Pwm_Braking48_H
 ENDIF
 
+t1_int_set_pwm:
+; Set PWM registers
 ; NOTE: Interrupts are not explicitly disabled. Assume higher priority
 ;       interrupts (Int0, Timer0) to be disabled at this point.
-IF PWM_BITS_H != PWM_8_BIT
     ; Set power pwm auto-reload registers
     Set_Power_Pwm_Reg_L Temp2
     Set_Power_Pwm_Reg_H Temp3
-ELSE
-    Set_Power_Pwm_Reg_H Temp2
-ENDIF
 
 IF DEADTIME != 0
     ; Set damp pwm auto-reload registers
-IF PWM_BITS_H != PWM_8_BIT
     Set_Damp_Pwm_Reg_L Temp4
     Set_Damp_Pwm_Reg_H Temp5
-ELSE
-    Set_Damp_Pwm_Reg_H Temp4
-ENDIF
 ENDIF
 
     mov  Rcp_Timeout_Cntd, #10          ; Set timeout count

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -374,9 +374,9 @@ t1_int_dynamic_pwm:
     mov A, Temp2
     mov Temp1, #Pgm_48to24_Threshold
     subb A, @Temp1
-    jnc t1_int_run_48khz
+    jc t1_int_run_48khz
 
-IF PWM_CENTERED == 1
+IF PWM_CENTERED == 0
 t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; No deadtime and 24khz

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -370,11 +370,10 @@ t1_int_zero_rcp_checked_check_limit:
 
 t1_int_dynamic_pwm:
     ; Dynamic PWM
-    clr C
-    mov A, Temp2
-    mov Temp1, #Pgm_48to24_Threshold
-    subb A, @Temp1
-    jc t1_int_run_48khz
+    clr  C
+    mov  A, Temp2
+    subb A, Throttle_48to24_Threshold
+    jc   t1_int_run_48khz
 
 IF PWM_CENTERED == 0
 t1_int_run_24khz:

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -210,9 +210,12 @@ ELSE
     anl  A, #0FEh
     mov  Pwm_Braking48_L, A
 ENDIF
-    cjne @Temp1, #0FFh, decode_end
+    cjne @Temp1, #0FFh, decode_throttle_threshold
     mov  Pwm_Braking24_L, #0FFh           ; Apply full braking if setting is max
     mov  Pwm_Braking48_L, #0FFh           ; Apply full braking if setting is max
 
-decode_end:
+decode_throttle_threshold:
+    ; Load programmed throttle threshold into Throttle_48to24_Threshold
+    mov  Temp1, #Pgm_48to24_Threshold
+    mov  Throttle_48to24_Threshold, @Temp1
     ret

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -215,7 +215,26 @@ ENDIF
     mov  Pwm_Braking48_L, #0FFh           ; Apply full braking if setting is max
 
 decode_throttle_threshold:
+    ; Load chosen frequency
+    mov Temp1, #Pgm_Pwm_Freq
+    mov A, @Temp1
+
+    ; Check 24khz pwm frequency
+    cjne A, #24, decode_throttle_not_24
+    mov  Throttle_48to24_Threshold, #255
+    jmp decode_throttle_end
+
+decode_throttle_not_24:
+    ; Check 48khz pwm frequency
+    cjne A, #48, decode_throttle_not_48
+    mov  Throttle_48to24_Threshold, #0
+    jmp decode_throttle_end
+
+decode_throttle_not_48:
+    ; Dynamic pwm frequency
     ; Load programmed throttle threshold into Throttle_48to24_Threshold
     mov  Temp1, #Pgm_48to24_Threshold
     mov  Throttle_48to24_Threshold, @Temp1
+
+decode_throttle_end:
     ret

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -37,7 +37,7 @@ set_default_parameters:
     imov Temp1, #DEFAULT_PGM_STARTUP_POWER_MAX ; Pgm_Startup_Power_Max
     imov Temp1, #0FFh                   ; _Pgm_Rampup_Slope
     imov Temp1, #DEFAULT_PGM_RPM_POWER_SLOPE ; Pgm_Rpm_Power_Slope
-    imov Temp1, #(24 SHL PWM_FREQ)      ; Pgm_Pwm_Freq
+    imov Temp1, #0FFh                   ; _Pgm_Pwm_Freq
     imov Temp1, #DEFAULT_PGM_DIRECTION  ; Pgm_Direction
     imov Temp1, #0FFh                   ; _Pgm_Input_Pol
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,7 +2,7 @@
 source_path=$(dirname $(pwd))
 
 usage() {
-  echo "Usage: $0 [-l <A-W>] [-m <X|H|L>] [-d <integer>] [-p <24|48|96>] [-s <version string>]" 1>&2
+  echo "Usage: $0 [-l <A-W>] [-m <X|H|L>] [-d <integer>] [-s <version string>]" 1>&2
   exit 1
 }
 
@@ -18,10 +18,6 @@ while getopts ":l:m:d:p:s:" o; do
     d)
       deadtime=${OPTARG}
       ;;
-    p)
-      pwm=${OPTARG}
-      ((pwm == 24 || pwm == 48 || pwm == 96)) || usage
-      ;;
     s)
       version=${OPTARG}
       ;;
@@ -32,18 +28,18 @@ while getopts ":l:m:d:p:s:" o; do
 done
 shift $((OPTIND-1))
 
-if [ -z "${layout}" ] && [ -z "${mcu}" ] && [ -z "${deadtime}" ] && [ -z "${pwm}" ]; then
+if [ -z "${layout}" ] && [ -z "${mcu}" ] && [ -z "${deadtime}" ]; then
   # All optional parameters are missing
   target="all"
   params="all"
 else
-  if [ -z "${layout}" ] || [ -z "${mcu}" ] || [ -z "${deadtime}" ] || [ -z "${pwm}" ]; then
+  if [ -z "${layout}" ] || [ -z "${mcu}" ] || [ -z "${deadtime}" ]; then
     # If one optional parameter is given, all are needed
     usage
   fi
 
-  target="${layout}_${mcu}_${deadtime}_${pwm}"
-  params="LAYOUT=${layout} MCU=${mcu} DEADTIME=${deadtime} PWM=${pwm}"
+  target="${layout}_${mcu}_${deadtime}"
+  params="LAYOUT=${layout} MCU=${mcu} DEADTIME=${deadtime}"
 fi
 
 if [ -n "${version}" ]; then


### PR DESCRIPTION
Dynamic PWM implementation removing also 96khz frequency mode.

96khz mode didn't have too many benefits over 48khz, and sometimes was problematic when deadtimes are high and weak motors.
