### PR TITLE
Allow to pass a dir when building that can contain a custom 'BluejayS…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Current version
 TAG			:= $(shell git describe --tags --abbrev=0)
 VERSION		?= $(TAG)
+SETTINGSDIR	?= ./src/Settings
 
 # Target parameters
 LAYOUTS		= A B C D E F G H I J K L M N O P Q R S T U V W Z \
@@ -90,6 +91,7 @@ $(OUTPUT_DIR)/$(1)_$(2)_$(3)_$(VERSION).OBJ : $(ASM_SRC) $(ASM_INC)
 	@mkdir -p $(OUTPUT_DIR)
 	@echo "AX51 : $$@"
 	@$(AX51) $(ASM_SRC) \
+		"INCDIR($(SETTINGSDIR)) " \
 		"DEFINE(ESCNO=$(_ESCNO)) " \
 		"DEFINE(MCU_TYPE=$(_MCU_TYPE)) "\
 		"DEFINE(DEADTIME=$(_DEADTIME)) "\

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -142,32 +142,10 @@ $include (Modules\Codespace.asm)
 $include (Modules\Common.asm)
 $include (Modules\Macros.asm)
 
-;**** **** **** **** **** **** **** **** **** **** **** **** ****
-; Programming defaults
-;**** **** **** **** **** **** **** **** **** **** **** **** ****
-DEFAULT_PGM_RPM_POWER_SLOPE EQU 9       ; 0=Off,1..13 (Power limit factor in relation to rpm)
-DEFAULT_PWM_FREQUENCY EQU 24            ; 24=24khz, 48=48khz, otherwise dynamic
-DEFAULT_PGM_COMM_TIMING EQU 4           ; 1=Low 2=MediumLow 3=Medium 4=MediumHigh 5=High
-DEFAULT_PGM_DEMAG_COMP EQU 2            ; 1=Disabled 2=Low 3=High
-DEFAULT_PGM_DIRECTION EQU 1             ; 1=Normal 2=Reversed 3=Bidir 4=Bidir rev
-DEFAULT_PGM_BEEP_STRENGTH EQU 40        ; 0..255 (BLHeli_S is 1..255)
-DEFAULT_PGM_BEACON_STRENGTH EQU 80      ; 0..255
-DEFAULT_PGM_BEACON_DELAY EQU 4          ; 1=1m 2=2m 3=5m 4=10m 5=Infinite
-DEFAULT_PGM_ENABLE_TEMP_PROT EQU 0      ; 0=Disabled 1=80C 2=90C 3=100C 4=110C 5=120C 6=130C 7=140C
-
-DEFAULT_PGM_POWER_RATING EQU 2          ; 1=1S,2=2S+
-
-DEFAULT_PGM_BRAKE_ON_STOP EQU 0         ; 1=Enabled 0=Disabled
-DEFAULT_PGM_LED_CONTROL EQU 0           ; Byte for LED control. 2 bits per LED,0=Off,1=On
-
-DEFAULT_PGM_STARTUP_POWER_MIN EQU 51    ; 0..255 => (1000..1125 Throttle): value * (1000 / 2047) + 1000
-DEFAULT_PGM_STARTUP_BEEP EQU 1          ; 0=Short beep,1=Melody
-
-DEFAULT_PGM_STARTUP_POWER_MAX EQU 25    ; 0..255 => (1000..2000 Throttle): Maximum startup power
-DEFAULT_PGM_BRAKING_STRENGTH EQU 255    ; 0..255 => 0..100 % Braking
-
-DEFAULT_PGM_SAFETY_ARM EQU 0            ; EDT safety arm is disabled by default
-DEFAULT_48to24_THRESHOLD EQU 170        ; About 66% threshold to change between 48 and 24khz
+; This file is Searched within the INCDIR set in the Makefile.
+; This allows overwriting the settings by putting a file with the same name in
+; a different directory and setting that in INCDIR.
+$include (BluejaySettings.asm)
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Temporary register definitions

--- a/src/Settings/BluejaySettings.asm
+++ b/src/Settings/BluejaySettings.asm
@@ -1,0 +1,52 @@
+;**** **** **** **** **** **** **** **** **** **** **** **** ****
+;
+; Bluejay digital ESC firmware for controlling brushless motors in multirotors
+;
+; Copyleft  2022-2023 Daniel Mosquera
+; Copyright 2020-2022 Mathias Rasmussen
+; Copyright 2011-2017 Steffen Skaug
+;
+; This file is part of Bluejay.
+;
+; Bluejay is free software: you can redistribute it and/or modify
+; it under the terms of the GNU General Public License as published by
+; the Free Software Foundation, either version 3 of the License, or
+; (at your option) any later version.
+;
+; Bluejay is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU General Public License for more details.
+;
+; You should have received a copy of the GNU General Public License
+; along with Bluejay.  If not, see <http://www.gnu.org/licenses/>.
+;
+;**** **** **** **** **** **** **** **** **** **** **** **** ****
+;
+; Programming defaults
+;
+;**** **** **** **** **** **** **** **** **** **** **** **** ****
+
+DEFAULT_PGM_RPM_POWER_SLOPE EQU 9       ; 0=Off,1..13 (Power limit factor in relation to rpm)
+DEFAULT_PWM_FREQUENCY EQU 24            ; 24=24khz, 48=48khz, otherwise dynamic
+DEFAULT_PGM_COMM_TIMING EQU 4           ; 1=Low 2=MediumLow 3=Medium 4=MediumHigh 5=High
+DEFAULT_PGM_DEMAG_COMP EQU 2            ; 1=Disabled 2=Low 3=High
+DEFAULT_PGM_DIRECTION EQU 1             ; 1=Normal 2=Reversed 3=Bidir 4=Bidir rev
+DEFAULT_PGM_BEEP_STRENGTH EQU 40        ; 0..255 (BLHeli_S is 1..255)
+DEFAULT_PGM_BEACON_STRENGTH EQU 80      ; 0..255
+DEFAULT_PGM_BEACON_DELAY EQU 4          ; 1=1m 2=2m 3=5m 4=10m 5=Infinite
+DEFAULT_PGM_ENABLE_TEMP_PROT EQU 0      ; 0=Disabled 1=80C 2=90C 3=100C 4=110C 5=120C 6=130C 7=140C
+
+DEFAULT_PGM_POWER_RATING EQU 2          ; 1=1S,2=2S+
+
+DEFAULT_PGM_BRAKE_ON_STOP EQU 0         ; 1=Enabled 0=Disabled
+DEFAULT_PGM_LED_CONTROL EQU 0           ; Byte for LED control. 2 bits per LED,0=Off,1=On
+
+DEFAULT_PGM_STARTUP_POWER_MIN EQU 51    ; 0..255 => (1000..1125 Throttle): value * (1000 / 2047) + 1000
+DEFAULT_PGM_STARTUP_BEEP EQU 1          ; 0=Short beep,1=Melody
+
+DEFAULT_PGM_STARTUP_POWER_MAX EQU 25    ; 0..255 => (1000..2000 Throttle): Maximum startup power
+DEFAULT_PGM_BRAKING_STRENGTH EQU 255    ; 0..255 => 0..100 % Braking
+
+DEFAULT_PGM_SAFETY_ARM EQU 0            ; EDT safety arm is disabled by default
+DEFAULT_48to24_THRESHOLD EQU 170        ; About 66% threshold to change between 48 and 24khz

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,11 +2,11 @@
 source_path=$(dirname $(pwd))
 
 usage() {
-  echo "Usage: $0 [-l <A-W>] [-m <X|H|L>] [-d <integer>] [-s <version string>]" 1>&2
+  echo "Usage: $0 [-l <A-W>] [-m <X|H|L>] [-d <integer>] [-s <version string>] [-c <custom settings dir path>]" 1>&2
   exit 1
 }
 
-while getopts ":l:m:d:p:s:" o; do
+while getopts ":l:m:d:p:s:c:" o; do
   case "${o}" in
     l)
       layout=${OPTARG}
@@ -20,6 +20,9 @@ while getopts ":l:m:d:p:s:" o; do
       ;;
     s)
       version=${OPTARG}
+      ;;
+    c)
+      settingsdir=${OPTARG}
       ;;
     *)
       usage
@@ -44,6 +47,10 @@ fi
 
 if [ -n "${version}" ]; then
   params="${params} VERSION=${version}"
+fi
+
+if [ -n "${settingsdir}" ]; then
+  params="${params} SETTINGSDIR=${settingsdir}"
 fi
 
 echo "Building ${target}"


### PR DESCRIPTION
…ettings.asm' overriding the one provided. This is intended for manufactureres to have a simple way to have custom configs