### PR TITLE
Feature/bring back 96khz mode

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -145,7 +145,7 @@ $include (Modules\Macros.asm)
 ; This file is Searched within the INCDIR set in the Makefile.
 ; This allows overwriting the settings by putting a file with the same name in
 ; a different directory and setting that in INCDIR.
-$include (Settings\BluejaySettings.asm)
+$include (BluejaySettings.asm)
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Temporary register definitions

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -145,7 +145,7 @@ $include (Modules\Macros.asm)
 ; This file is Searched within the INCDIR set in the Makefile.
 ; This allows overwriting the settings by putting a file with the same name in
 ; a different directory and setting that in INCDIR.
-$include (BluejaySettings.asm)
+$include (Settings\BluejaySettings.asm)
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 ; Temporary register definitions

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -243,6 +243,8 @@ Pwm_Braking24_L: DS 1                   ; Max Braking @24khz pwm (lo byte)
 Pwm_Braking24_H: DS 1                   ; Max Braking @24khz pwm (hi byte)
 Pwm_Braking48_L: DS 1                   ; Max Braking @48khz pwm (lo byte)
 Pwm_Braking48_H: DS 1                   ; Max Braking @48khz pwm (hi byte)
+Pwm_Braking96_L: DS 1                   ; Max Braking @96khz pwm (lo byte)
+Pwm_Braking96_H: DS 1                   ; Max Braking @96khz pwm (hi byte)
 Temp_Prot_Limit: DS 1                   ; Temperature protection limit
 Temp_Pwm_Level_Setpoint: DS 1           ; PWM level setpoint
 Beep_Strength: DS 1                     ; Strength of beeps
@@ -266,6 +268,7 @@ DShot_GCR_Start_Delay: DS 1
 Ext_Telemetry_L: DS 1                   ; Extended telemetry data to be sent
 Ext_Telemetry_H: DS 1
 Scheduler_Counter: DS 1                 ; Scheduler Heartbeat
+Throttle_96to48_Threshold: DS 1         ; Threshold to switch between 24 and 48khz
 Throttle_48to24_Threshold: DS 1         ; Threshold to switch between 24 and 48khz
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
@@ -312,6 +315,7 @@ Pgm_Brake_On_Stop: DS 1                 ; Braking when throttle is zero
 Pgm_LED_Control: DS 1                   ; LED control
 Pgm_Power_Rating: DS 1                  ; Power rating
 Pgm_Safety_Arm: DS 1                    ; Various flag settings: bit 0 is require edt enable to arm
+Pgm_96to48_Threshold: DS 1              ; Threshold to move between 96 and 48 khz PWM frequency
 Pgm_48to24_Threshold: DS 1              ; Threshold to move between 48 and 24 khz PWM frequency
 
 ISEG AT 0C0h
@@ -328,7 +332,7 @@ CSEG AT CSEG_EEPROM
 EEPROM_FW_MAIN_REVISION EQU 0           ; Main revision of the firmware
 EEPROM_FW_SUB_REVISION EQU 21           ; Sub revision of the firmware
 EEPROM_LAYOUT_REVISION EQU 208          ; Revision of the EEPROM layout
-EEPROM_B2_PARAMETERS_COUNT EQU 29       ; Number of parameters
+EEPROM_B2_PARAMETERS_COUNT EQU 30       ; Number of parameters
 
 Eep_FW_Main_Revision: DB EEPROM_FW_MAIN_REVISION ; EEPROM firmware main revision number
 Eep_FW_Sub_Revision: DB EEPROM_FW_SUB_REVISION ; EEPROM firmware sub revision number
@@ -374,6 +378,7 @@ Eep_Pgm_Brake_On_Stop: DB DEFAULT_PGM_BRAKE_ON_STOP ; EEPROM copy of programmed 
 Eep_Pgm_LED_Control: DB DEFAULT_PGM_LED_CONTROL ; EEPROM copy of programmed LED control
 Eep_Pgm_Power_Rating: DB DEFAULT_PGM_POWER_RATING ; EEPROM copy of programmed power rating
 Eep_Pgm_Safety_Arm: DB DEFAULT_PGM_SAFETY_ARM ; Various flag settings: bit 0 is require edt enable to arm
+Eep_Pgm_96to48_Threshold: DB DEFAULT_48to24_THRESHOLD ; Threshold to move between 96 and 48 khz PWM frequency
 Eep_Pgm_48to24_Threshold: DB DEFAULT_48to24_THRESHOLD ; Threshold to move between 48 and 24 khz PWM frequency
 
 

--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -378,7 +378,7 @@ Eep_Pgm_Brake_On_Stop: DB DEFAULT_PGM_BRAKE_ON_STOP ; EEPROM copy of programmed 
 Eep_Pgm_LED_Control: DB DEFAULT_PGM_LED_CONTROL ; EEPROM copy of programmed LED control
 Eep_Pgm_Power_Rating: DB DEFAULT_PGM_POWER_RATING ; EEPROM copy of programmed power rating
 Eep_Pgm_Safety_Arm: DB DEFAULT_PGM_SAFETY_ARM ; Various flag settings: bit 0 is require edt enable to arm
-Eep_Pgm_96to48_Threshold: DB DEFAULT_48to24_THRESHOLD ; Threshold to move between 96 and 48 khz PWM frequency
+Eep_Pgm_96to48_Threshold: DB DEFAULT_96to48_THRESHOLD ; Threshold to move between 96 and 48 khz PWM frequency
 Eep_Pgm_48to24_Threshold: DB DEFAULT_48to24_THRESHOLD ; Threshold to move between 48 and 24 khz PWM frequency
 
 

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -370,12 +370,22 @@ t1_int_zero_rcp_checked_check_limit:
 
 t1_int_dynamic_pwm:
     ; Dynamic PWM
-    clr  C
     mov  A, Temp2
+
+    ; Choose between 96khz and 48khz
+    clr  C
+    subb A, Throttle_96to48_Threshold
+    jc   t1_int_run_96khz
+
+    ; Choose between 48khz and 24khz
+    clr  C
     subb A, Throttle_48to24_Threshold
     jc   t1_int_run_48khz
 
+
 IF PWM_CENTERED == 0
+
+    ; Edge aligned PWM
 t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; No deadtime and 24khz
@@ -408,7 +418,31 @@ t1_int_run_48khz:
 
     ; Set PCA to work at 48khz
     mov  PCA0PWM, #82h
+
+    jmp t1_int_set_pwm
+
+t1_int_run_96khz:
+        mov  B, Temp5
+    mov  A, Temp4
+    mov  C, B.0
+    rrc  A
+    mov  C, B.1
+    rrc  A
+    cpl  A
+    mov  Temp2, A
+    mov  A, Temp5
+    rr   A
+    rr   A
+    cpl  A
+    anl  A, #1
+    mov  Temp3, A
+
+    ; Set PCA to work at 96khz
+    mov  PCA0PWM, #81h
+
 ELSE
+
+    ; Center aligned PWM
 t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; Deadtime and 24khz
@@ -453,6 +487,7 @@ t1_int_max_braking_set_24khz:
     mov  A, Temp5
     subb A, Pwm_Braking24_H             ; Is braking pwm more than maximum allowed braking?
     jc   t1_int_set_pwm                 ; Yes - branch
+
     mov  Temp4, Pwm_Braking24_L         ; No - set desired braking instead
     mov  Temp5, Pwm_Braking24_H
     jmp t1_int_set_pwm
@@ -505,9 +540,55 @@ t1_int_max_braking_set_48khz:
     mov  A, Temp5
     subb A, Pwm_Braking48_H             ; Is braking pwm more than maximum allowed braking?
     jc   t1_int_set_pwm                 ; Yes - branch
+
     mov  Temp4, Pwm_Braking48_L         ; No - set desired braking instead
     mov  Temp5, Pwm_Braking48_H
+    jmp t1_int_set_pwm
+
+t1_int_run_96khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 96khz
+    mov  A, Temp2                       ; Temp2 already 8-bit
+    cpl  A
+    mov  Temp2, A
+    mov  Temp3, #0
+
+    ; Set PCA to work at 96khz
+    mov  PCA0PWM, #80h
+
+    ; Subtract dead time from normal pwm and store as damping PWM
+    ; Damping PWM duty cycle will be higher because numbers are inverted
+    clr  C
+    mov  A, Temp2                       ; Skew damping FET timing
+IF MCU_TYPE == MCU_BB1
+    subb A, #((DEADTIME + 1) SHR 1)
+ELSE
+    subb A, #(DEADTIME)
 ENDIF
+    mov  Temp4, A
+    mov  A, Temp3
+    subb A, #0
+    mov  Temp5, A
+    jnc  t1_int_max_braking_set_96khz
+
+    clr  A                              ; Set to minimum value
+    mov  Temp4, A
+    mov  Temp5, A
+    sjmp t1_int_set_pwm                 ; Max braking is already zero - branch
+
+t1_int_max_braking_set_96khz:
+    clr  C
+    mov  A, Temp4
+    subb A, Pwm_Braking96_L
+    mov  A, Temp5
+    subb A, Pwm_Braking96_H             ; Is braking pwm more than maximum allowed braking?
+    jc   t1_int_set_pwm                 ; Yes - branch
+
+    mov  Temp4, Pwm_Braking96_L         ; No - set desired braking instead
+    mov  Temp5, Pwm_Braking96_H
+
+ENDIF
+
 
 t1_int_set_pwm:
 ; Set PWM registers

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -422,7 +422,9 @@ t1_int_run_48khz:
     jmp t1_int_set_pwm
 
 t1_int_run_96khz:
-        mov  B, Temp5
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 96khz
+    mov  B, Temp5
     mov  A, Temp4
     mov  C, B.0
     rrc  A

--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -385,7 +385,9 @@ t1_int_dynamic_pwm:
 
 IF PWM_CENTERED == 0
 
-    ; Edge aligned PWM
+; *******************
+;  Edge aligned PWM
+; *******************
 t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; No deadtime and 24khz
@@ -399,7 +401,6 @@ t1_int_run_24khz:
 
     ; Set PCA to work at 24khz
     mov  PCA0PWM, #83h
-
     jmp t1_int_set_pwm
 
 t1_int_run_48khz:
@@ -418,7 +419,6 @@ t1_int_run_48khz:
 
     ; Set PCA to work at 48khz
     mov  PCA0PWM, #82h
-
     jmp t1_int_set_pwm
 
 t1_int_run_96khz:
@@ -440,9 +440,11 @@ t1_int_run_96khz:
     ; Set PCA to work at 96khz
     mov  PCA0PWM, #81h
 
-ELSE
+ELSE                                    ; (PWM_CENTERED == 0)
 
-    ; Center aligned PWM
+; *******************
+; Center aligned PWM
+; *******************
 t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; Deadtime and 24khz
@@ -587,7 +589,7 @@ t1_int_max_braking_set_96khz:
     mov  Temp4, Pwm_Braking96_L         ; No - set desired braking instead
     mov  Temp5, Pwm_Braking96_H
 
-ENDIF
+ENDIF                                   ; (PWM_CENTERED == 0)
 
 
 t1_int_set_pwm:

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -72,6 +72,7 @@ set_default_parameters:
     imov Temp1, #DEFAULT_PGM_LED_CONTROL ; Pgm_LED_Control
     imov Temp1, #DEFAULT_PGM_POWER_RATING ; Pgm_Power_Rating
     imov Temp1, #DEFAULT_PGM_SAFETY_ARM ; Pgm_Safety_Arm
+    imov Temp1, #DEFAULT_96to48_THRESHOLD ; Pgm_96to48_Threshold
     imov Temp1, #DEFAULT_48to24_THRESHOLD ; Pgm_48to24_Threshold
 
     ret

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -165,33 +165,14 @@ decode_temp_done:
     mov  Temp1, #Pgm_Beep_Strength      ; Read programmed beep strength setting
     mov  Beep_Strength, @Temp1          ; Set beep strength
 
-    mov  Temp1, #Pgm_Braking_Strength   ; Read programmed braking strength setting
+    ; Read programmed braking strength setting
+    mov  Temp1, #Pgm_Braking_Strength
+
+    ; Scale braking strength to pwm resolution
+    ; Only for center aligned pwm modes (edge aligned pwm insert deadtime by hw)
+IF PWM_CENTERED == 1
+    ; Deadtime & 24khz (10bit pwm)
     mov  A, @Temp1
-IF PWM_CENTERED == 1             ; Scale braking strength to pwm resolution
-    ; Note: Added for completeness
-    ; Currently 11-bit pwm is only used on targets with built-in dead time insertion
-    ; No deadtime & 24khz
-    rl   A
-    rl   A
-    rl   A
-    mov  Temp2, A
-    anl  A, #07h
-    mov  Pwm_Braking24_H, A
-    mov  A, Temp2
-    anl  A, #0F8h
-    mov  Pwm_Braking24_L, A
-
-    ; Deadtime & 48khz
-    rl   A
-    rl   A
-    mov  Temp2, A
-    anl  A, #03h
-    mov  Pwm_Braking48_H, A
-    mov  A, Temp2
-    anl  A, #0FCh
-    mov  Pwm_Braking48_L, A
-ELSE
-    ; Deadtime & 24khz
     rl   A
     rl   A
     mov  Temp2, A
@@ -201,7 +182,8 @@ ELSE
     anl  A, #0FCh
     mov  Pwm_Braking24_L, A
 
-    ; Deadtime & 48khz
+    ; Deadtime & 48khz (9bit pwm)
+    mov  A, @Temp1
     rl   A
     mov  Temp2, A
     anl  A, #01h
@@ -209,32 +191,63 @@ ELSE
     mov  A, Temp2
     anl  A, #0FEh
     mov  Pwm_Braking48_L, A
-ENDIF
+
+    ; Deadtime & 96khz (8bit pwm)
+    mov  A, @Temp1
+    mov  Pwm_Braking96_H, #0
+    mov  Pwm_Braking96_L, A
+
     cjne @Temp1, #0FFh, decode_throttle_threshold
     mov  Pwm_Braking24_L, #0FFh           ; Apply full braking if setting is max
     mov  Pwm_Braking48_L, #0FFh           ; Apply full braking if setting is max
+    mov  Pwm_Braking96_L, #0FFh           ; Apply full braking if setting is max
+ENDIF
 
 decode_throttle_threshold:
     ; Load chosen frequency
-    mov Temp1, #Pgm_Pwm_Freq
-    mov A, @Temp1
+    mov  Temp1, #Pgm_Pwm_Freq
+    mov  A, @Temp1
 
     ; Check 24khz pwm frequency
     cjne A, #24, decode_throttle_not_24
+    mov  Throttle_96to48_Threshold, #0
     mov  Throttle_48to24_Threshold, #0
-    jmp decode_throttle_end
+    jmp  decode_throttle_end
 
 decode_throttle_not_24:
     ; Check 48khz pwm frequency
     cjne A, #48, decode_throttle_not_48
+    mov  Throttle_96to48_Threshold, #0
     mov  Throttle_48to24_Threshold, #255
-    jmp decode_throttle_end
+    jmp  decode_throttle_end
 
 decode_throttle_not_48:
+    ; Check 96khz pwm frequency
+    cjne A, #96, decode_throttle_not_48
+    mov  Throttle_96to48_Threshold, #255
+    mov  Throttle_48to24_Threshold, #255
+    jmp  decode_throttle_end
+
+decode_throttle_not_96:
     ; Dynamic pwm frequency
+    ; Load programmed throttle threshold into Throttle_96to48_Threshold
+    mov  Temp1, #Pgm_96to48_Threshold
+    mov  Throttle_96to48_Threshold, @Temp1
+
     ; Load programmed throttle threshold into Throttle_48to24_Threshold
     mov  Temp1, #Pgm_48to24_Threshold
     mov  Throttle_48to24_Threshold, @Temp1
 
+    ; Sanitize Throttle_48to24_Threshold
+    clr C
+    mov  A, Throttle_48to24_Threshold
+    subb A, Throttle_96to48_Threshold
+    jnc  decode_throttle_end
+    clr  A
+
 decode_throttle_end:
+    ; Update Throttle_48to24_Threshold
+    mov Throttle_48to24_Threshold, A
+
+decode_end:
     ret

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -213,21 +213,21 @@ decode_throttle_threshold:
     cjne A, #24, decode_throttle_not_24
     mov  Throttle_96to48_Threshold, #0
     mov  Throttle_48to24_Threshold, #0
-    jmp  decode_throttle_end
+    jmp  decode_end
 
 decode_throttle_not_24:
     ; Check 48khz pwm frequency
     cjne A, #48, decode_throttle_not_48
     mov  Throttle_96to48_Threshold, #0
     mov  Throttle_48to24_Threshold, #255
-    jmp  decode_throttle_end
+    jmp  decode_end
 
 decode_throttle_not_48:
     ; Check 96khz pwm frequency
-    cjne A, #96, decode_throttle_not_48
+    cjne A, #96, decode_throttle_not_96
     mov  Throttle_96to48_Threshold, #255
     mov  Throttle_48to24_Threshold, #255
-    jmp  decode_throttle_end
+    jmp  decode_end
 
 decode_throttle_not_96:
     ; Dynamic pwm frequency
@@ -243,10 +243,10 @@ decode_throttle_not_96:
     clr C
     mov  A, Throttle_48to24_Threshold
     subb A, Throttle_96to48_Threshold
-    jnc  decode_throttle_end
+    jnc  decode_throttle_not_96_end
     clr  A
 
-decode_throttle_end:
+decode_throttle_not_96_end:
     ; Update Throttle_48to24_Threshold
     mov Throttle_48to24_Threshold, A
 

--- a/src/Settings/BluejaySettings.asm
+++ b/src/Settings/BluejaySettings.asm
@@ -28,7 +28,7 @@
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 
 DEFAULT_PGM_RPM_POWER_SLOPE EQU 9       ; 0=Off,1..13 (Power limit factor in relation to rpm)
-DEFAULT_PWM_FREQUENCY EQU 24            ; 24=24khz, 48=48khz, otherwise dynamic
+DEFAULT_PWM_FREQUENCY EQU 24            ; 24=24khz, 48=48khz, 96=96khz, otherwise dynamic
 DEFAULT_PGM_COMM_TIMING EQU 4           ; 1=Low 2=MediumLow 3=Medium 4=MediumHigh 5=High
 DEFAULT_PGM_DEMAG_COMP EQU 2            ; 1=Disabled 2=Low 3=High
 DEFAULT_PGM_DIRECTION EQU 1             ; 1=Normal 2=Reversed 3=Bidir 4=Bidir rev

--- a/src/Settings/BluejaySettings.asm
+++ b/src/Settings/BluejaySettings.asm
@@ -49,4 +49,5 @@ DEFAULT_PGM_STARTUP_POWER_MAX EQU 25    ; 0..255 => (1000..2000 Throttle): Maxim
 DEFAULT_PGM_BRAKING_STRENGTH EQU 255    ; 0..255 => 0..100 % Braking
 
 DEFAULT_PGM_SAFETY_ARM EQU 0            ; EDT safety arm is disabled by default
+DEFAULT_96to48_THRESHOLD EQU 85         ; About 33% threshold to change between 96 and 48khz
 DEFAULT_48to24_THRESHOLD EQU 170        ; About 66% threshold to change between 48 and 24khz


### PR DESCRIPTION
This commit brings back 96khz mode because there seem to be lots of people using it.
It also fixes broken braking values in previous dynamic pwm pr