### PR TITLE
Remove power limits after initial run phase is done

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -926,9 +926,6 @@ run6:
 startup_phase_done:
     ; Clear startup phase flag & remove pwm limits
     clr  Flag_Startup_Phase
-    mov  Pwm_Limit_By_Rpm, #255
-    mov  Pwm_Limit, #255                ; Reset temperature level pwm limit
-    mov  Temp_Pwm_Level_Setpoint, #255  ; Reset temperature level setpoint
 
 initial_run_phase:
     ; If it is a direction change - branch
@@ -949,6 +946,16 @@ initial_run_phase:
 
 initial_run_phase_done:
     clr  Flag_Initial_Run_Phase         ; Clear initial run phase flag
+
+    ; Lift startup power restrictions
+    ; Temperature protection acts until this point
+    ; as a max startup power limiter.
+    ; This plus the power limits applied in set_pwm_limit function
+    ; act as a startup power limiter to protect the esc and the motor
+    ; during startup, jams produced after crashes and desyncs recovery
+    mov  Pwm_Limit, #255                ; Reset temperature level pwm limit
+    mov  Temp_Pwm_Level_Setpoint, #255  ; Reset temperature level setpoint
+
     setb Flag_Motor_Started             ; Set motor started
     jmp  run1                           ; Continue with normal run
 

--- a/src/Modules/Power.asm
+++ b/src/Modules/Power.asm
@@ -57,7 +57,7 @@ set_pwm_limit_low_rpm:
     mov  Temp1, Pwm_Limit_Beg
 
     ; Exit if startup phase is set
-    jb   Flag_Initial_Run_Phase, set_pwm_limit_low_rpm_exit
+    jb   Flag_Startup_Phase, set_pwm_limit_low_rpm_exit
 
     ; Set default pwm limit for other phases
     mov  Temp1, #0FFh                   ; Default full power
@@ -79,9 +79,13 @@ set_pwm_limit_calculate:
     mul  AB
     mov  Temp1, A                       ; Set new limit
     xch  A, B
+
+    ; If RPM_PWM_LIMIT < 255 goto set_pwm_limit_check_limit_to_min
     jz   set_pwm_limit_check_limit_to_min ; Limit to max
 
-    mov  Temp1, #0FFh
+    ; Limit is bigger than 0xFF -> set max pwm and exit
+    mov  Pwm_Limit_By_Rpm, #0FFh
+    ret
 
 set_pwm_limit_check_limit_to_min:
     clr  C


### PR DESCRIPTION
This pr moves the release of startup power limits until the end of the initial run phase:
![imagen](https://github.com/bird-sanctuary/bluejay/assets/2889851/06e2ff38-5f0a-4f07-96b2-193a0b6325ed)
