### PR TITLE
Refactoring/exit startup power

### DIFF
--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -347,7 +347,7 @@ t1_int_zero_rcp_checked:
 t1_int_zero_rcp_checked_set_limit:
     ; Set pwm limit
     clr  C
-    mov  A, Pwm_Limit                   ; Limit to the smallest
+    mov  A, Pwm_Limit_Startup_n_Temp    ; Limit to the smallest
     mov  Temp6, A                       ; Store limit in Temp6
     subb A, Pwm_Limit_By_Rpm
     jc   t1_int_zero_rcp_checked_check_limit

--- a/src/Modules/Power.asm
+++ b/src/Modules/Power.asm
@@ -35,9 +35,16 @@
 ;
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****
 switch_power_off:
+    ; This three macros disable MOSFET communtation.
+    ; Dshot frames will have no effect after disabling MOSFET communtation.
+    ; Commutation is started again at motor_start_bidir_done.
     All_Pwm_Fets_Off                    ; Turn off all pwm FETs
     All_Com_Fets_Off                    ; Turn off all commutation FETs
     Set_All_Pwm_Phases_Off
+
+    ; Enforce all PWM limits to zero to disable dshot frame rcpulses
+    mov  Pwm_Limit_By_Rpm, #0
+    mov  Pwm_Limit_Startup_n_Temp, #0
     ret
 
 ;**** **** **** **** **** **** **** **** **** **** **** **** ****

--- a/src/Modules/Scheduler.asm
+++ b/src/Modules/Scheduler.asm
@@ -183,21 +183,21 @@ scheduler_steps_odd:
     ; resulting in current spikes, that may damage motor/ESC.
     ; Compare pwm limit to setpoint
     clr  C
-    mov  A, Pwm_Limit
+    mov  A, Pwm_Limit_Startup_n_Temp
     subb A, Temp_Pwm_Level_Setpoint
     jz   scheduler_steps_odd_choose_step ; pwm limit == setpoint -> next
     jc   scheduler_steps_odd_temp_pwm_limit_inc ; pwm limit < setpoint -> increase pwm limit
 
 scheduler_steps_odd_temp_pwm_limit_dec:
     ; Decrease pwm limit
-    dec  Pwm_Limit
+    dec  Pwm_Limit_Startup_n_Temp
 
     ; Continue with odd scheduler step selection
     sjmp scheduler_steps_odd_choose_step
 
 scheduler_steps_odd_temp_pwm_limit_inc:
     ; Increase pwm limit
-    inc  Pwm_Limit
+    inc  Pwm_Limit_Startup_n_Temp
 
 ; Run speciffic odd scheduler step
 scheduler_steps_odd_choose_step:


### PR DESCRIPTION
Refactored exit_startup_power to improve coherency.
Updated switch_power_off to also set Pwm_Limits to zero to enforce shut down
Renamed Pwm_Limit to Pwm_Limit_Startup_n_Temp to make more clear the use of this variable

