### PR TITLE
Flag_Ext_Tele can only be cleared in exit_run_mode when motors are not being reversed (turtle mode)

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -1046,7 +1046,6 @@ exit_run_mode:
     call switch_power_off
     mov  Flags0, #0                     ; Clear run time flags (in case they are used in interrupts)
     mov  Flags1, #0
-    clr  Flag_Ext_Tele                  ; Clear extended DSHOT telemetry flag
 
 IF MCU_TYPE == MCU_BB2 or MCU_TYPE == MCU_BB51
     Set_MCU_Clk_24MHz


### PR DESCRIPTION
Flag_Ext_Tele can only be cleared in exit_run_mode when motors are not being reversed (turtle mode)
That step is done in the lowest part of exit_run_mode