### PR TITLE
Rework of pwm modes to use 24/48/96khz modes from low to high throttle

### DIFF
--- a/src/Modules/Isrs.asm
+++ b/src/Modules/Isrs.asm
@@ -372,28 +372,39 @@ t1_int_dynamic_pwm:
     ; Dynamic PWM
     mov  A, Temp2
 
-    ; Choose between 96khz and 48khz
-    clr  C
-    subb A, Throttle_96to48_Threshold
-    jc   t1_int_run_96khz
-
     ; Choose between 48khz and 24khz
     clr  C
     subb A, Throttle_48to24_Threshold
+    jc   t1_int_run_24khz
+
+    ; Choose between 96khz and 48khz
+    clr  C
+    subb A, Throttle_96to48_Threshold
     jc   t1_int_run_48khz
 
 
 IF PWM_CENTERED == 0                    ;  Edge aligned PWM
 
-t1_int_run_24khz:
+t1_int_run_96khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
-    ; No deadtime and 24khz
-    mov  A, Temp5
-    cpl  A
-    anl  A, #7
-    mov  Temp3, A
+    ; Deadtime and 96khz
+    mov  B, Temp5
     mov  A, Temp4
+    mov  C, B.0
+    rrc  A
+    mov  C, B.1
+    rrc  A
     cpl  A
+    mov  Temp2, A
+    mov  A, Temp5
+    rr   A
+    rr   A
+    cpl  A
+    anl  A, #1
+    mov  Temp3, A
+
+    ; Set PCA to work at 96khz (9bit pwm)
+    mov  PCA0PWM, #81h
     mov  Temp2, A
 
     ; Set PCA to work at 24khz (11bit pwm)
@@ -418,26 +429,15 @@ t1_int_run_48khz:
     mov  PCA0PWM, #82h
     jmp t1_int_set_pwm
 
-t1_int_run_96khz:
+t1_int_run_24khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
-    ; Deadtime and 96khz
-    mov  B, Temp5
-    mov  A, Temp4
-    mov  C, B.0
-    rrc  A
-    mov  C, B.1
-    rrc  A
-    cpl  A
-    mov  Temp2, A
+    ; No deadtime and 24khz
     mov  A, Temp5
-    rr   A
-    rr   A
     cpl  A
-    anl  A, #1
+    anl  A, #7
     mov  Temp3, A
-
-    ; Set PCA to work at 96khz (9bit pwm)
-    mov  PCA0PWM, #81h
+    mov  A, Temp4
+    cpl  A
 
 t1_int_set_pwm:
 ; Set PWM registers
@@ -449,108 +449,6 @@ t1_int_set_pwm:
 
 ELSE                                    ; Center aligned PWM
 
-t1_int_run_24khz:
-    ; Scale pwm resolution and invert (duty cycle is defined inversely)
-    ; Deadtime and 24khz
-    clr  C
-    mov  A, Temp5
-    rrc  A
-    cpl  A
-    anl  A, #3
-    mov  Temp3, A
-    mov  A, Temp4
-    rrc  A
-    cpl  A
-    mov  Temp2, A
-
-    ; Set PCA to work at 24khz (10bit pwm)
-    mov  PCA0PWM, #82h
-
-    ; Subtract dead time from normal pwm and store as damping PWM
-    ; Damping PWM duty cycle will be higher because numbers are inverted
-    clr  C
-    mov  A, Temp2                       ; Skew damping FET timing
-IF MCU_TYPE == MCU_BB1
-    subb A, #((DEADTIME + 1) SHR 1)
-ELSE
-    subb A, #(DEADTIME)
-ENDIF
-    mov  Temp4, A
-    mov  A, Temp3
-    subb A, #0
-    mov  Temp5, A
-    jnc  t1_int_max_braking_set_24khz
-
-    clr  A                              ; Set to minimum value
-    mov  Temp4, A
-    mov  Temp5, A
-    jmp t1_int_set_pwm                  ; Max braking is already zero - branch
-
-t1_int_max_braking_set_24khz:
-    clr  C
-    mov  A, Temp4
-    subb A, Pwm_Braking24_L
-    mov  A, Temp5
-    subb A, Pwm_Braking24_H             ; Is braking pwm more than maximum allowed braking?
-    jc   t1_int_set_pwm                 ; Yes - branch
-
-    mov  Temp4, Pwm_Braking24_L         ; No - set desired braking instead
-    mov  Temp5, Pwm_Braking24_H
-    jmp t1_int_set_pwm
-
-t1_int_run_48khz:
-    ; Scale pwm resolution and invert (duty cycle is defined inversely)
-    ; Deadtime and 48khz
-    mov  B, Temp5
-    mov  A, Temp4
-    mov  C, B.0
-    rrc  A
-    mov  C, B.1
-    rrc  A
-    cpl  A
-    mov  Temp2, A
-    mov  A, Temp5
-    rr   A
-    rr   A
-    cpl  A
-    anl  A, #1
-    mov  Temp3, A
-
-    ; Set PCA to work at 48khz (9bit pwm)
-    mov  PCA0PWM, #81h
-
-    ; Subtract dead time from normal pwm and store as damping PWM
-    ; Damping PWM duty cycle will be higher because numbers are inverted
-    clr  C
-    mov  A, Temp2                       ; Skew damping FET timing
-IF MCU_TYPE == MCU_BB1
-    subb A, #((DEADTIME + 1) SHR 1)
-ELSE
-    subb A, #(DEADTIME)
-ENDIF
-    mov  Temp4, A
-    mov  A, Temp3
-    subb A, #0
-    mov  Temp5, A
-    jnc  t1_int_max_braking_set_48khz
-
-    clr  A                              ; Set to minimum value
-    mov  Temp4, A
-    mov  Temp5, A
-    sjmp t1_int_set_pwm                 ; Max braking is already zero - branch
-
-t1_int_max_braking_set_48khz:
-    clr  C
-    mov  A, Temp4
-    subb A, Pwm_Braking48_L
-    mov  A, Temp5
-    subb A, Pwm_Braking48_H             ; Is braking pwm more than maximum allowed braking?
-    jc   t1_int_set_pwm                 ; Yes - branch
-
-    mov  Temp4, Pwm_Braking48_L         ; No - set desired braking instead
-    mov  Temp5, Pwm_Braking48_H
-    jmp t1_int_set_pwm
-
 t1_int_run_96khz:
     ; Scale pwm resolution and invert (duty cycle is defined inversely)
     ; Deadtime and 96khz
@@ -559,10 +457,7 @@ t1_int_run_96khz:
     mov  Temp2, A
     mov  Temp3, #0
 
-    ; Set PCA to work at 96khz (8bit pwm)
-    mov  PCA0PWM, #80h
-
-    ; Subtract dead time from normal pwm and store as damping PWM
+    ; Substract dead time from normal pwm and store as damping PWM
     ; Damping PWM duty cycle will be higher because numbers are inverted
     clr  C
     mov  A, Temp2                       ; Skew damping FET timing
@@ -597,6 +492,9 @@ t1_int_set_pwm_96khz:
 ; Set PWM registers
 ; NOTE: Interrupts are not explicitly disabled. Assume higher priority
 ;       interrupts (Int0, Timer0) to be disabled at this point.
+    ; Set PCA to work at 96khz (8bit pwm)
+    mov  PCA0PWM, #80h
+
     ; Set power pwm auto-reload registers
     Set_Power_Pwm_Reg_H Temp2
 
@@ -604,10 +502,123 @@ t1_int_set_pwm_96khz:
     Set_Damp_Pwm_Reg_H Temp4
     jmp  t1_int_prepare_telemetry
 
-t1_int_set_pwm:
+t1_int_run_48khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 48khz
+    mov  B, Temp5
+    mov  A, Temp4
+    mov  C, B.0
+    rrc  A
+    mov  C, B.1
+    rrc  A
+    cpl  A
+    mov  Temp2, A
+    mov  A, Temp5
+    rr   A
+    rr   A
+    cpl  A
+    anl  A, #1
+    mov  Temp3, A
+
+    ; Substract dead time from normal pwm and store as damping PWM
+    ; Damping PWM duty cycle will be higher because numbers are inverted
+    clr  C
+    mov  A, Temp2                       ; Skew damping FET timing
+IF MCU_TYPE == MCU_BB1
+    subb A, #((DEADTIME + 1) SHR 1)
+ELSE
+    subb A, #(DEADTIME)
+ENDIF
+    mov  Temp4, A
+    mov  A, Temp3
+    subb A, #0
+    mov  Temp5, A
+    jnc  t1_int_max_braking_set_48khz
+
+    clr  A                              ; Set to minimum value
+    mov  Temp4, A
+    mov  Temp5, A
+    sjmp t1_int_set_pwm_48khz           ; Max braking is already zero - branch
+
+t1_int_max_braking_set_48khz:
+    clr  C
+    mov  A, Temp4
+    subb A, Pwm_Braking48_L
+    mov  A, Temp5
+    subb A, Pwm_Braking48_H             ; Is braking pwm more than maximum allowed braking?
+    jc   t1_int_set_pwm_48khz           ; Yes - branch
+
+    mov  Temp4, Pwm_Braking48_L         ; No - set desired braking instead
+    mov  Temp5, Pwm_Braking48_H
+
+t1_int_set_pwm_48khz:
 ; Set PWM registers
 ; NOTE: Interrupts are not explicitly disabled. Assume higher priority
 ;       interrupts (Int0, Timer0) to be disabled at this point.
+    ; Set PCA to work at 48khz (9bit pwm)
+    mov  PCA0PWM, #81h
+
+    ; Set power pwm auto-reload registers
+    Set_Power_Pwm_Reg_L Temp2
+    Set_Power_Pwm_Reg_H Temp3
+
+    ; Set damp pwm auto-reload registers
+    Set_Damp_Pwm_Reg_L Temp4
+    Set_Damp_Pwm_Reg_H Temp5
+    jmp  t1_int_prepare_telemetry
+
+t1_int_run_24khz:
+    ; Scale pwm resolution and invert (duty cycle is defined inversely)
+    ; Deadtime and 24khz
+    clr  C
+    mov  A, Temp5
+    rrc  A
+    cpl  A
+    anl  A, #3
+    mov  Temp3, A
+    mov  A, Temp4
+    rrc  A
+    cpl  A
+    mov  Temp2, A
+
+    ; Substract dead time from normal pwm and store as damping PWM
+    ; Damping PWM duty cycle will be higher because numbers are inverted
+    clr  C
+    mov  A, Temp2                       ; Skew damping FET timing
+IF MCU_TYPE == MCU_BB1
+    subb A, #((DEADTIME + 1) SHR 1)
+ELSE
+    subb A, #(DEADTIME)
+ENDIF
+    mov  Temp4, A
+    mov  A, Temp3
+    subb A, #0
+    mov  Temp5, A
+    jnc  t1_int_max_braking_set_24khz
+
+    clr  A                              ; Set to minimum value
+    mov  Temp4, A
+    mov  Temp5, A
+    jmp t1_int_set_pwm_24khz            ; Max braking is already zero - branch
+
+t1_int_max_braking_set_24khz:
+    clr  C
+    mov  A, Temp4
+    subb A, Pwm_Braking24_L
+    mov  A, Temp5
+    subb A, Pwm_Braking24_H             ; Is braking pwm more than maximum allowed braking?
+    jc   t1_int_set_pwm_24khz                 ; Yes - branch
+
+    mov  Temp4, Pwm_Braking24_L         ; No - set desired braking instead
+    mov  Temp5, Pwm_Braking24_H
+
+t1_int_set_pwm_24khz:
+; Set PWM registers
+; NOTE: Interrupts are not explicitly disabled. Assume higher priority
+;       interrupts (Int0, Timer0) to be disabled at this point.
+    ; Set PCA to work at 24khz (10bit pwm)
+    mov  PCA0PWM, #82h
+
     ; Set power pwm auto-reload registers
     Set_Power_Pwm_Reg_L Temp2
     Set_Power_Pwm_Reg_H Temp3

--- a/src/Modules/Settings.asm
+++ b/src/Modules/Settings.asm
@@ -211,44 +211,44 @@ decode_throttle_threshold:
 
     ; Check 24khz pwm frequency
     cjne A, #24, decode_throttle_not_24
-    mov  Throttle_96to48_Threshold, #0
-    mov  Throttle_48to24_Threshold, #0
+    mov  Throttle_96to48_Threshold, #255
+    mov  Throttle_48to24_Threshold, #255
     jmp  decode_end
 
 decode_throttle_not_24:
     ; Check 48khz pwm frequency
     cjne A, #48, decode_throttle_not_48
-    mov  Throttle_96to48_Threshold, #0
-    mov  Throttle_48to24_Threshold, #255
+    mov  Throttle_96to48_Threshold, #255
+    mov  Throttle_48to24_Threshold, #0
     jmp  decode_end
 
 decode_throttle_not_48:
     ; Check 96khz pwm frequency
     cjne A, #96, decode_throttle_not_96
-    mov  Throttle_96to48_Threshold, #255
-    mov  Throttle_48to24_Threshold, #255
+    mov  Throttle_96to48_Threshold, #0
+    mov  Throttle_48to24_Threshold, #0
     jmp  decode_end
 
 decode_throttle_not_96:
     ; Dynamic pwm frequency
-    ; Load programmed throttle threshold into Throttle_96to48_Threshold
-    mov  Temp1, #Pgm_96to48_Threshold
-    mov  Throttle_96to48_Threshold, @Temp1
-
     ; Load programmed throttle threshold into Throttle_48to24_Threshold
     mov  Temp1, #Pgm_48to24_Threshold
     mov  Throttle_48to24_Threshold, @Temp1
 
-    ; Sanitize Throttle_48to24_Threshold
+    ; Load programmed throttle threshold into Throttle_96to48_Threshold
+    mov  Temp1, #Pgm_96to48_Threshold
+    mov  Throttle_96to48_Threshold, @Temp1
+
+    ; Sanitize Throttle_96to48_Threshold
     clr C
-    mov  A, Throttle_48to24_Threshold
-    subb A, Throttle_96to48_Threshold
+    mov  A, Throttle_96to48_Threshold
+    subb A, Throttle_48to24_Threshold
     jnc  decode_throttle_not_96_end
     clr  A
 
 decode_throttle_not_96_end:
-    ; Update Throttle_48to24_Threshold
-    mov Throttle_48to24_Threshold, A
+    ; Update Throttle_96to48_Threshold
+    mov Throttle_96to48_Threshold, A
 
 decode_end:
     ret


### PR DESCRIPTION
This pr reworks pwm modes so:
- 24khz mode is used at low throttle
- 48khz mode is used at mid throttle
- 96khz mode is used at high throttle