### PR TITLE
Remove delay in wait_for_start_nonzero

### DIFF
--- a/src/Bluejay.asm
+++ b/src/Bluejay.asm
@@ -724,8 +724,6 @@ wait_for_start_check_rcp:
     sjmp wait_for_start_loop            ; Go back to beginning of wait loop
 
 wait_for_start_nonzero:
-    call wait100ms                      ; Wait to see if start pulse was glitch
-
     ; If RC pulse returned to stop (0) - start over
     jb   Flag_Rcp_Stop, wait_for_start_loop
 


### PR DESCRIPTION
There's a 100ms delay in wait_for_start_nonzero because with PWM input you sometimes have glitch pulses from electrical noise, and you don't want to start the motor on a glitch. But bluejay no longer supports PWM input and is dshot-only, so glitches are no longer possible, particularly because there's a checksum in the dshot protocol.

This 100ms delay is a major issue for applications which need to start a stopped motor, such as nerf blasters and robotics. Currently blheli_s and bluejay are unusable in these applications, and this one-line change would fix that