### PR TITLE
Prescribe user settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/user
 /tools/.wine
 *.diff
 .project


### PR DESCRIPTION
Add `user/` direction to .gitignore

Custom settings integration with current Docker volume configuration requires that settings folder is within the cloned repository folder.

For documentation and ease of use, prescribing a directory that is ignored by git will be helpful