### PR TITLE
Reset max stress level metric to minimum 

### DIFF
--- a/src/Modules/Scheduler.asm
+++ b/src/Modules/Scheduler.asm
@@ -242,6 +242,7 @@ scheduler_steps_odd_status_frame_max_loaded:
     clr  Flag_Demag_Notify
     clr  Flag_Desync_Notify
     clr  Flag_Stall_Notify
+    mov  Demag_Detected_Metric_Max, #0  ; Reset the Max metric so the next value would reflect maximum seen during the time in between STATUS telemetry packets
 
     ; Load status frame
     mov  Ext_Telemetry_L, A             ; Set telemetry low value to status data


### PR DESCRIPTION
### Current Behavior
The `Demag_Detected_Metric_Max` currently stores the maximum value observed since the ESC was armed. This results in the metric becoming static after reaching its peak, never decreasing until the ESC is disarmed.

### Proposed Change
Reset the `Demag_Detected_Metric_Max` metric each time a STATUS telemetry packet is sent. So that the value in a STATUS telemetry packet would represent the Max stress level in the last second (according to current scheduler implementation).

### Rationale
- Offload the logic of processing the max stress level to the FC (e.g., Betaflight), allowing for more sophisticated and/or different modes of analysis.
- FC side alarms will be able to activate only when stress is genuinely high, rather than remaining permanently active after the threshold is exceeded.
- Make the behavior consistent with Demag/Desync/Stall flags, which are also part of the STATUS EDT packet.
- Speaking of blackbox logs, such change would provide meaningful data throughout the entire flight, instead of only capturing information before the first high-stress situation like a snap roll.

### Tests
This is what 40 seconds of blackbox log look like if recorded with this change.
![Screenshot 2024-09-13 at 00 34 28](https://github.com/user-attachments/assets/ae2cb7ae-94d5-41df-9b23-e094ac2a011d)
